### PR TITLE
Add tximport-style transcript-length normalization   and pytximport support

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -49,6 +49,26 @@ jobs:
         if: matrix.python == '3.11'
         run: |
           uv run mypy -p pydeseq2
+      - name: Test SciPy 1.13 sparse compatibility
+        if: matrix.python == '3.11'
+        run: |
+          uv run --no-project --isolated --python 3.11 \
+            --with-editable . \
+            --with 'numpy==2.0.0' \
+            --with 'scipy==1.13.0' \
+            --with 'anndata==0.11.0' \
+            --with 'zarr<3' \
+            --with 'pytest==8.4.0' \
+            python -m pytest -q \
+            'tests/test_transcript_length_normalization.py::test_sparse_anndata_ratio_pipeline_matches_dense[csr_matrix]' \
+            'tests/test_transcript_length_normalization.py::test_sparse_anndata_ratio_pipeline_matches_dense[csr_array]' \
+            'tests/test_transcript_length_normalization.py::test_sparse_array_cooks_outlier[csr_array]' \
+            'tests/test_transcript_length_normalization.py::test_general_sparse_anndata_pipeline_matches_dense' \
+            'tests/test_transcript_length_normalization.py::test_general_sparse_transcript_length_counts' \
+            'tests/test_transcript_length_normalization.py::test_sparse_anndata_sums_duplicates_before_validation' \
+            'tests/test_utils.py::test_valid_sparse_count_formats' \
+            'tests/test_utils.py::test_valid_dia_counts_ignore_padding' \
+            'tests/test_utils.py::test_invalid_general_sparse_counts'
       - name: Test with pytest
         run: |
           uv run coverage run -m pytest

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           uv run ruff format --check pydeseq2
       - name: Type check with mypy
+        if: matrix.python == '3.11'
         run: |
           uv run mypy -p pydeseq2
       - name: Test with pytest

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -57,18 +57,12 @@ jobs:
             --with 'numpy==2.0.0' \
             --with 'scipy==1.13.0' \
             --with 'anndata==0.11.0' \
+            --with 'pandas==2.2.2' \
             --with 'zarr<3' \
             --with 'pytest==8.4.0' \
             python -m pytest -q \
-            'tests/test_transcript_length_normalization.py::test_sparse_anndata_ratio_pipeline_matches_dense[csr_matrix]' \
-            'tests/test_transcript_length_normalization.py::test_sparse_anndata_ratio_pipeline_matches_dense[csr_array]' \
-            'tests/test_transcript_length_normalization.py::test_sparse_array_cooks_outlier[csr_array]' \
-            'tests/test_transcript_length_normalization.py::test_general_sparse_anndata_pipeline_matches_dense' \
-            'tests/test_transcript_length_normalization.py::test_general_sparse_transcript_length_counts' \
-            'tests/test_transcript_length_normalization.py::test_sparse_anndata_sums_duplicates_before_validation' \
-            'tests/test_utils.py::test_valid_sparse_count_formats' \
-            'tests/test_utils.py::test_valid_dia_counts_ignore_padding' \
-            'tests/test_utils.py::test_invalid_general_sparse_counts'
+            tests/test_transcript_length_normalization.py \
+            tests/test_utils.py
       - name: Test with pytest
         run: |
           uv run coverage run -m pytest

--- a/README.md
+++ b/README.md
@@ -119,45 +119,27 @@ produce a compatible AnnData object directly:
 from pydeseq2.dds import DeseqDataSet
 from pytximport import tximport
 
-sample_files = {
-    "sample_1": "sample_1/quant.sf",
-    "sample_2": "sample_2/quant.sf",
-}
-
+sample_names = ["sample_1", "sample_2"]
 txi = tximport(
-    list(sample_files.values()),
+    [f"{sample}/quant.sf" for sample in sample_names],
     data_type="salmon",
     transcript_gene_map=transcript_gene_map,
     counts_from_abundance=None,
     output_type="anndata",
 )
-# pytximport uses file paths as observation names. Replace them with metadata
-# rows in the same explicit sample order.
-txi.obs = metadata.loc[list(sample_files)].copy()
-
+txi.obs = metadata.loc[sample_names].copy()
 dds = DeseqDataSet(adata=txi, design="~condition")
 dds.deseq2()
 ```
 
-Direct transcript-length normalization requires an in-memory AnnData object.
-For a backed object, call `adata.to_memory()` before constructing `DeseqDataSet`;
-this materializes the data, so ensure sufficient memory is available.
-
-Only unscaled estimated counts created with `counts_from_abundance=None` may be
-combined with transcript-length offsets. PyDESeq2 rejects abundance-derived modes
-such as `scaled_tpm` and `length_scaled_tpm`, because applying the offset would
-correct for transcript length twice.
-
-After the unscaled-count check succeeds, when multiple length sources are
-available, PyDESeq2 uses an explicit `transcript_lengths` argument first, then
-`adata.layers["avg_tx_length"]`, and finally compatible pytximport fields.
-Pytximport lengths are copied from
-`adata.obsm["length"]` into the canonical `avg_tx_length` layer.
-
-The current pytximport length matrix has no gene labels, and AnnData does not align
-its second `obsm` dimension with `adata.var`. Pass the object before gene-axis
-subsetting or reordering, or apply the same selection and ordering to
-`adata.obsm["length"]`.
+Use only unscaled estimated counts (`counts_from_abundance=None`); the file list and
+metadata rows must use the same sample order. For backed AnnData, call
+`adata.to_memory()` first and ensure sufficient memory. Length-source precedence is
+deterministic: explicit `transcript_lengths`, `adata.layers["avg_tx_length"]`, then
+compatible pytximport fields; PyDESeq2 copies `adata.obsm["length"]` into the canonical
+layer. Because that matrix has no gene labels and AnnData does not align its second
+`obsm` dimension with `adata.var`, pass it before gene-axis subsetting/reordering or
+apply the same selection and order to `adata.obsm["length"]`.
 
 Following the
 [`tximport`](https://bioconductor.org/packages/release/bioc/html/tximport.html) and

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ In case there is a feature you would particularly like to be implemented, feel f
   - [Installation](#installation)
     - [Requirements](#requirements)
   - [Getting started](#getting-started)
+    - [Transcript-length normalization](#transcript-length-normalization)
     - [Documentation](#documentation)
     - [Data](#data)
   - [Contributing](#contributing)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,31 @@ Please don't hesitate to open an issue in case you encounter any issue due to po
 The [Getting Started](https://pydeseq2.readthedocs.io/en/latest/auto_examples/index.html) section of the documentation
 contains downloadable examples on how to use PyDESeq2.
 
+### Transcript-length normalization
+
+For unscaled estimated gene counts imported from transcript-level quantifiers
+(`countsFromAbundance="no"` in tximport), pass the matching average transcript lengths
+alongside the counts. Both matrices must use samples as rows and genes as columns. When
+using data frames, their labels and ordering must be identical; arrays must already use
+the same ordering:
+
+```python
+dds = DeseqDataSet(
+    counts=estimated_counts,
+    metadata=metadata,
+    transcript_lengths=average_transcript_lengths,
+    design="~condition",
+)
+dds.deseq2()
+```
+
+Following DESeq2's `DESeqDataSetFromTximport()` workflow, PyDESeq2 rounds estimated
+counts and combines transcript-length offsets with median-of-ratios library-size
+normalization. Average lengths and the resulting sample-by-gene factors are available
+in `dds.layers["avg_tx_length"]` and `dds.layers["normalization_factors"]`.
+The `ratio` and `poscounts` size-factor methods are supported; `iterative` is not
+currently compatible with transcript-length offsets.
+
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -111,12 +111,62 @@ dds = DeseqDataSet(
 dds.deseq2()
 ```
 
-Following DESeq2's `DESeqDataSetFromTximport()` workflow, PyDESeq2 rounds estimated
-counts and combines transcript-length offsets with median-of-ratios library-size
-normalization. Average lengths and the resulting sample-by-gene factors are available
-in `dds.layers["avg_tx_length"]` and `dds.layers["normalization_factors"]`.
-The `ratio` and `poscounts` size-factor methods are supported; `iterative` is not
-currently compatible with transcript-length offsets.
+[`pytximport`](https://github.com/complextissue/pytximport), described in [4], can
+produce a compatible AnnData object directly:
+
+```python
+from pydeseq2.dds import DeseqDataSet
+from pytximport import tximport
+
+sample_files = {
+    "sample_1": "sample_1/quant.sf",
+    "sample_2": "sample_2/quant.sf",
+}
+
+txi = tximport(
+    list(sample_files.values()),
+    data_type="salmon",
+    transcript_gene_map=transcript_gene_map,
+    counts_from_abundance=None,
+    output_type="anndata",
+)
+# pytximport uses file paths as observation names. Replace them with metadata
+# rows in the same explicit sample order.
+txi.obs = metadata.loc[list(sample_files)].copy()
+
+dds = DeseqDataSet(adata=txi, design="~condition")
+dds.deseq2()
+```
+
+Direct transcript-length normalization requires an in-memory AnnData object.
+For a backed object, call `adata.to_memory()` before constructing `DeseqDataSet`;
+this materializes the data, so ensure sufficient memory is available.
+
+Only unscaled estimated counts created with `counts_from_abundance=None` may be
+combined with transcript-length offsets. PyDESeq2 rejects abundance-derived modes
+such as `scaled_tpm` and `length_scaled_tpm`, because applying the offset would
+correct for transcript length twice.
+
+After the unscaled-count check succeeds, when multiple length sources are
+available, PyDESeq2 uses an explicit `transcript_lengths` argument first, then
+`adata.layers["avg_tx_length"]`, and finally compatible pytximport fields.
+Pytximport lengths are copied from
+`adata.obsm["length"]` into the canonical `avg_tx_length` layer.
+
+The current pytximport length matrix has no gene labels, and AnnData does not align
+its second `obsm` dimension with `adata.var`. Pass the object before gene-axis
+subsetting or reordering, or apply the same selection and ordering to
+`adata.obsm["length"]`.
+
+Following the
+[`tximport`](https://bioconductor.org/packages/release/bioc/html/tximport.html) and
+[`DESeq2`](https://bioconductor.org/packages/release/bioc/html/DESeq2.html)
+workflow [1, 3], PyDESeq2 rounds estimated counts and combines transcript-length
+offsets with median-of-ratios library-size normalization. Average lengths and the
+resulting sample-by-gene factors are available in `dds.layers["avg_tx_length"]`
+and `dds.layers["normalization_factors"]`. The `ratio` and `poscounts`
+size-factor methods are supported; `iterative` is not currently compatible with
+transcript-length offsets.
 
 
 ### Documentation
@@ -183,6 +233,16 @@ In Dec 2025, the maintenance of PyDESeq2 was taken over by the scverse community
         removing the noise and preserving large differences."
         Bioinformatics, 35(12), 2084-2092.
         <https://academic.oup.com/bioinformatics/article/35/12/2084/5159452>
+
+[3] Soneson, C., Love, M. I., & Robinson, M. D. (2015). "Differential analyses
+        for RNA-seq: transcript-level estimates improve gene-level inferences."
+        F1000Research, 4:1521.
+        <https://doi.org/10.12688/f1000research.7563.1>
+
+[4] Kuehl, M., Wong, M. N., Wanner, N., Bonn, S., & Puelles, V. G. (2024).
+        "Gene count estimation with pytximport enables reproducible analysis of
+        bulk RNA sequencing data in Python." Bioinformatics, 40(12), btae700.
+        <https://doi.org/10.1093/bioinformatics/btae700>
 
 ## License
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,6 +56,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "pandas": ("https://pandas.pydata.org/docs/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "anndata": ("https://anndata.readthedocs.io/en/latest/", None),
 }
 

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -38,7 +38,9 @@ def _rounded_counts(counts: Any) -> Any:
     if isinstance(counts, np.ndarray):
         return np.rint(counts)
     rounded = counts.copy()
+    rounded.sum_duplicates()
     rounded.data = np.rint(rounded.data)
+    rounded.eliminate_zeros()
     return rounded
 
 
@@ -57,7 +59,11 @@ class DeseqDataSet(ad.AnnData):
     adata : anndata.AnnData
         AnnData from which to initialize the DeseqDataSet. Must have counts ('X') and
         sample metadata ('obs') fields. If ``None``, both ``counts`` and ``metadata``
-        arguments must be provided.
+        arguments must be provided. Compatible pytximport objects with unscaled
+        estimated counts are detected from ``obsm["length"]`` and
+        ``uns["counts_from_abundance"] is None``.
+        Backed AnnData objects are not supported; call ``adata.to_memory()`` before
+        initialization.
 
     counts : pandas.DataFrame
         Raw counts. One column per gene, rows are indexed by sample barcodes.
@@ -74,7 +80,9 @@ class DeseqDataSet(ad.AnnData):
         ``counts``. When provided, PyDESeq2
         constructs gene- and sample-specific normalization factors that correct for
         transcript-length changes as well as library size. Estimated counts are rounded
-        to the nearest integer, matching DESeq2. (default: ``None``).
+        to the nearest integer, matching DESeq2. Explicit lengths take precedence over
+        ``adata.layers["avg_tx_length"]``, which takes precedence over compatible
+        pytximport fields. (default: ``None``).
 
     design : str or pandas.DataFrame
         Model design. Can be either a pandas DataFrame representing a design matrix, or
@@ -253,10 +261,39 @@ class DeseqDataSet(ad.AnnData):
         low_memory: bool = False,
     ) -> None:
         # Initialize the AnnData part
-        has_transcript_lengths = transcript_lengths is not None or (
+        has_stored_transcript_lengths = (
             adata is not None and "avg_tx_length" in adata.layers
         )
+        selected_transcript_lengths: Any = transcript_lengths
+        has_transcript_lengths = (
+            selected_transcript_lengths is not None or has_stored_transcript_lengths
+        )
         if adata is not None:
+            has_pytximport_fields = (
+                "length" in adata.obsm and "counts_from_abundance" in adata.uns
+            )
+            has_transcript_lengths = has_transcript_lengths or has_pytximport_fields
+            counts_from_abundance = adata.uns.get("counts_from_abundance")
+            if counts_from_abundance is not None and has_transcript_lengths:
+                raise ValueError(
+                    "pytximport transcript-length offsets require unscaled "
+                    "estimated counts with "
+                    "adata.uns['counts_from_abundance'] set to None; got "
+                    f"{counts_from_abundance!r}. Abundance-scaled counts must "
+                    "not be combined with transcript-length offsets."
+                )
+            if (
+                has_pytximport_fields
+                and selected_transcript_lengths is None
+                and not has_stored_transcript_lengths
+            ):
+                selected_transcript_lengths = adata.obsm["length"]
+
+            if adata.isbacked:
+                raise ValueError(
+                    "DeseqDataSet requires an in-memory AnnData object. Call "
+                    "adata.to_memory() before initialization."
+                )
             expected_length_index = adata.obs_names
             expected_length_columns = adata.var_names
             if counts is not None:
@@ -267,15 +304,41 @@ class DeseqDataSet(ad.AnnData):
                 warnings.warn(
                     "adata was provided; ignoring metadata.", UserWarning, stacklevel=2
                 )
-            prepared_counts = (
+            prepared_counts: Any = (
                 _rounded_counts(adata.X) if has_transcript_lengths else adata.X
             )
             # Test counts before going further
             test_valid_counts(prepared_counts)
-            # Copy fields from original AnnData
-            self.__dict__.update(adata.__dict__)
-            # Cast counts to ints to avoid any issue
-            self.X = prepared_counts.astype(int)
+            integer_counts = prepared_counts.astype(int)
+            if has_transcript_lengths:
+                # Own the containers PyDESeq2 writes while retaining references to
+                # existing large aligned matrices.
+                # AnnData migrates legacy neighbor matrices out of uns in place.
+                owned_uns = dict(adata.uns)
+                if "neighbors" in owned_uns:
+                    owned_uns["neighbors"] = dict(owned_uns["neighbors"])
+                super().__init__(
+                    X=integer_counts,
+                    obs=cast(pd.DataFrame, adata.obs).copy(),
+                    var=cast(pd.DataFrame, adata.var).copy(),
+                    uns=None,
+                    obsm=cast(Any, dict(adata.obsm)),
+                    varm=cast(Any, dict(adata.varm)),
+                    obsp=cast(Any, dict(adata.obsp)),
+                    varp=cast(Any, dict(adata.varp)),
+                    # AnnData 0.13 can expose X as a None-keyed layer item.
+                    layers={
+                        key: value
+                        for key, value in adata.layers.items()
+                        if key is not None
+                    },
+                    raw=cast(Any, adata.raw),
+                )
+                self.uns.update(owned_uns)
+            else:
+                # Preserve the existing AnnData initialization behavior.
+                self.__dict__.update(adata.__dict__)
+                self.X = integer_counts
         elif counts is not None and metadata is not None:
             expected_length_index = counts.index
             expected_length_columns = counts.columns
@@ -290,25 +353,31 @@ class DeseqDataSet(ad.AnnData):
                 "Either adata or both counts and metadata arguments must be provided."
             )
 
-        if transcript_lengths is not None:
-            if isinstance(transcript_lengths, pd.DataFrame):
-                if not transcript_lengths.index.equals(expected_length_index):
+        if selected_transcript_lengths is not None:
+            if isinstance(selected_transcript_lengths, pd.DataFrame):
+                if not selected_transcript_lengths.index.equals(expected_length_index):
                     raise ValueError(
                         "transcript_lengths must have the same sample index as counts."
                     )
-                if not transcript_lengths.columns.equals(expected_length_columns):
+                if not selected_transcript_lengths.columns.equals(
+                    expected_length_columns
+                ):
                     raise ValueError(
                         "transcript_lengths must have the same gene columns as counts."
                     )
-                transcript_lengths_array = transcript_lengths.to_numpy(dtype=float)
+                transcript_lengths_array = selected_transcript_lengths.to_numpy(
+                    dtype=float, copy=True
+                )
             else:
-                transcript_lengths_array = np.asarray(transcript_lengths, dtype=float)
+                transcript_lengths_array = np.array(
+                    selected_transcript_lengths, dtype=float, copy=True
+                )
             self._validate_transcript_lengths(transcript_lengths_array)
             self.layers["avg_tx_length"] = transcript_lengths_array
         elif "avg_tx_length" in self.layers:
             stored_lengths = self.layers["avg_tx_length"]
             transcript_lengths_array = (
-                stored_lengths.toarray()
+                cast(Any, stored_lengths).toarray()
                 if hasattr(stored_lengths, "toarray")
                 else np.asarray(stored_lengths, dtype=float)
             )
@@ -540,7 +609,7 @@ class DeseqDataSet(ad.AnnData):
         """
         # Start by fitting median-of-ratio size factors if not already present,
         # or if they were computed iteratively
-        if "size_factors" not in self.obsm or self.logmeans is None:
+        if "size_factors" not in self.obs or self.logmeans is None:
             self.fit_size_factors(
                 fit_type=self.size_factors_fit_type
             )  # by default, fit_type != "iterative"
@@ -899,7 +968,7 @@ class DeseqDataSet(ad.AnnData):
             self.fit_size_factors(fit_type=self.size_factors_fit_type)
 
         # Exclude genes with all zeroes
-        self.var["non_zero"] = ~(self.X == 0).all(axis=0)
+        self.var["non_zero"] = np.asarray((self.X != 0).sum(axis=0)).ravel() > 0
         self.non_zero_idx = np.arange(self.n_vars)[self.var["non_zero"]]
         self.non_zero_genes = self.var_names[self.var["non_zero"]]
 
@@ -1185,7 +1254,13 @@ class DeseqDataSet(ad.AnnData):
         )
 
         # Calculate the squared pearson residuals for non-zero features
-        squared_pearson_res = self.X[:, self.var["non_zero"]] - self.obsm["_mu_LFC"]
+        counts = self.X[:, self.non_zero_idx]
+        if hasattr(counts, "tocoo"):
+            counts = counts.tocoo()
+            squared_pearson_res = -self.obsm["_mu_LFC"].copy()
+            np.add.at(squared_pearson_res, (counts.row, counts.col), counts.data)
+        else:
+            squared_pearson_res = counts - self.obsm["_mu_LFC"]
         squared_pearson_res **= 2
 
         # Calculate the overdispersion parameter tau
@@ -1274,11 +1349,13 @@ class DeseqDataSet(ad.AnnData):
                 axis=0
             )
 
-        pos = self.layers["cooks"][:, cooks_outlier].argmax(0)
-
-        cooks_outlier[cooks_outlier] = (
-            self.X[:, cooks_outlier] > self.X[:, cooks_outlier][pos, np.arange(len(pos))]
-        ).sum(axis=0) < 3
+        pos = np.asarray(self.layers["cooks"][:, cooks_outlier].argmax(0)).ravel()
+        for gene_idx, sample_idx in zip(np.flatnonzero(cooks_outlier), pos, strict=True):
+            gene_counts = self.X[:, gene_idx]
+            if hasattr(gene_counts, "toarray"):
+                gene_counts = gene_counts.toarray()
+            gene_counts = np.asarray(gene_counts).ravel()
+            cooks_outlier[gene_idx] = (gene_counts > gene_counts[sample_idx]).sum() < 3
 
         if self.low_memory:
             del self.layers["cooks"]
@@ -1511,6 +1588,8 @@ class DeseqDataSet(ad.AnnData):
         if sum(self.var["replaced"] > 0):
             # Compute replacement counts: trimmed means * normalization factors
             self.counts_to_refit = self[:, self.var["replaced"]].copy()
+            if hasattr(self.counts_to_refit.X, "toarray"):
+                self.counts_to_refit.X = self.counts_to_refit.X.toarray()
             normalization_factors = self._get_normalization_factors()
             if normalization_factors.ndim == 1:
                 normalization_factors = normalization_factors[:, None]

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -1,6 +1,7 @@
 import sys
 import time
 import warnings
+from typing import Any
 from typing import Literal
 from typing import cast
 
@@ -30,6 +31,17 @@ from pydeseq2.utils import trimmed_mean
 warnings.simplefilter("ignore", FutureWarning)
 
 
+def _rounded_counts(counts: Any) -> Any:
+    """Round dense or sparse estimated counts without mutating the input."""
+    if isinstance(counts, pd.DataFrame):
+        return counts.round()
+    if isinstance(counts, np.ndarray):
+        return np.rint(counts)
+    rounded = counts.copy()
+    rounded.data = np.rint(rounded.data)
+    return rounded
+
+
 class DeseqDataSet(ad.AnnData):
     r"""A class to implement dispersion and log fold-change (LFC) estimation.
 
@@ -53,6 +65,16 @@ class DeseqDataSet(ad.AnnData):
     metadata : pandas.DataFrame
         DataFrame containing sample metadata.
         Must be indexed by sample barcodes.
+
+    transcript_lengths : pandas.DataFrame or numpy.ndarray, optional
+        Average transcript lengths for each sample and gene, typically imported from
+        transcript-level quantification with unscaled estimated counts (tximport's
+        ``countsFromAbundance="no"`` mode). Scaled TPM-derived counts must not be paired
+        with these offsets. Must have the same sample-by-gene shape and ordering as
+        ``counts``. When provided, PyDESeq2
+        constructs gene- and sample-specific normalization factors that correct for
+        transcript-length changes as well as library size. Estimated counts are rounded
+        to the nearest integer, matching DESeq2. (default: ``None``).
 
     design : str or pandas.DataFrame
         Model design. Can be either a pandas DataFrame representing a design matrix, or
@@ -161,6 +183,8 @@ class DeseqDataSet(ad.AnnData):
 
     layers
         Key-indexed multi-dimensional arrays aligned to dimensions of `X`, e.g. "cooks".
+        Average transcript lengths and the resulting factors are stored as
+        ``"avg_tx_length"`` and ``"normalization_factors"``, respectively.
 
     n_processes : int
         Number of cpus to use for multiprocessing.
@@ -209,6 +233,7 @@ class DeseqDataSet(ad.AnnData):
         adata: ad.AnnData | None = None,
         counts: pd.DataFrame | None = None,
         metadata: pd.DataFrame | None = None,
+        transcript_lengths: pd.DataFrame | np.ndarray | None = None,
         design: str | pd.DataFrame = "~condition",
         design_factors: str | list[str] | None = None,
         continuous_factors: list[str] | None = None,
@@ -228,7 +253,12 @@ class DeseqDataSet(ad.AnnData):
         low_memory: bool = False,
     ) -> None:
         # Initialize the AnnData part
+        has_transcript_lengths = transcript_lengths is not None or (
+            adata is not None and "avg_tx_length" in adata.layers
+        )
         if adata is not None:
+            expected_length_index = adata.obs_names
+            expected_length_columns = adata.var_names
             if counts is not None:
                 warnings.warn(
                     "adata was provided; ignoring counts.", UserWarning, stacklevel=2
@@ -237,20 +267,53 @@ class DeseqDataSet(ad.AnnData):
                 warnings.warn(
                     "adata was provided; ignoring metadata.", UserWarning, stacklevel=2
                 )
+            prepared_counts = (
+                _rounded_counts(adata.X) if has_transcript_lengths else adata.X
+            )
             # Test counts before going further
-            test_valid_counts(adata.X)
+            test_valid_counts(prepared_counts)
             # Copy fields from original AnnData
             self.__dict__.update(adata.__dict__)
             # Cast counts to ints to avoid any issue
-            self.X = adata.X.astype(int)
+            self.X = prepared_counts.astype(int)
         elif counts is not None and metadata is not None:
+            expected_length_index = counts.index
+            expected_length_columns = counts.columns
+            prepared_counts = (
+                _rounded_counts(counts) if has_transcript_lengths else counts
+            )
             # Test counts before going further
-            test_valid_counts(counts)
-            super().__init__(X=counts.astype(int), obs=metadata)
+            test_valid_counts(prepared_counts)
+            super().__init__(X=prepared_counts.astype(int), obs=metadata)
         else:
             raise ValueError(
                 "Either adata or both counts and metadata arguments must be provided."
             )
+
+        if transcript_lengths is not None:
+            if isinstance(transcript_lengths, pd.DataFrame):
+                if not transcript_lengths.index.equals(expected_length_index):
+                    raise ValueError(
+                        "transcript_lengths must have the same sample index as counts."
+                    )
+                if not transcript_lengths.columns.equals(expected_length_columns):
+                    raise ValueError(
+                        "transcript_lengths must have the same gene columns as counts."
+                    )
+                transcript_lengths_array = transcript_lengths.to_numpy(dtype=float)
+            else:
+                transcript_lengths_array = np.asarray(transcript_lengths, dtype=float)
+            self._validate_transcript_lengths(transcript_lengths_array)
+            self.layers["avg_tx_length"] = transcript_lengths_array
+        elif "avg_tx_length" in self.layers:
+            stored_lengths = self.layers["avg_tx_length"]
+            transcript_lengths_array = (
+                stored_lengths.toarray()
+                if hasattr(stored_lengths, "toarray")
+                else np.asarray(stored_lengths, dtype=float)
+            )
+            self._validate_transcript_lengths(transcript_lengths_array)
+            self.layers["avg_tx_length"] = transcript_lengths_array
 
         self.fit_type = fit_type
         self.design = design
@@ -334,6 +397,82 @@ class DeseqDataSet(ad.AnnData):
 
         # Initialize the inference object.
         self.inference = inference or DefaultInference(n_cpus=n_cpus)
+
+    def _validate_transcript_lengths(self, transcript_lengths: np.ndarray) -> None:
+        """Validate a sample-by-gene average transcript-length matrix."""
+        if transcript_lengths.shape != self.shape:
+            raise ValueError(
+                "transcript_lengths must have the same shape as counts "
+                f"({self.shape}), got {transcript_lengths.shape}."
+            )
+        if not np.isfinite(transcript_lengths).all():
+            raise ValueError("transcript_lengths must only contain finite values.")
+        if (transcript_lengths <= 0).any():
+            raise ValueError("transcript_lengths must contain only positive values.")
+
+    def _get_normalization_factors(self) -> np.ndarray:
+        """Return gene-specific factors when present, otherwise sample size factors."""
+        if "normalization_factors" in self.layers:
+            return np.asarray(self.layers["normalization_factors"])
+        return self.obs["size_factors"].to_numpy()
+
+    def _fit_transcript_length_factors(
+        self,
+        fit_type: Literal["ratio", "poscounts"],
+        control_mask: np.ndarray,
+    ) -> None:
+        """Fit DESeq2-style normalization factors from average transcript lengths."""
+        counts = np.asarray(
+            cast(Any, self.X).toarray() if hasattr(self.X, "toarray") else self.X
+        )
+        transcript_lengths = np.asarray(self.layers["avg_tx_length"])
+
+        # DESeq2 centers each gene's average transcript lengths around a geometric
+        # mean of one before estimating library-size factors on adjusted counts.
+        length_factors = transcript_lengths / np.exp(
+            np.mean(np.log(transcript_lengths), axis=0)
+        )
+        adjusted_counts = counts / length_factors
+
+        if fit_type == "ratio":
+            self.logmeans, self.filtered_genes = deseq2_norm_fit(adjusted_counts)
+        else:
+            log_counts = np.zeros_like(counts, dtype=float)
+            np.log(counts, out=log_counts, where=counts != 0)
+            self.logmeans = log_counts.mean(axis=0)
+            self.filtered_genes = counts.sum(axis=0) > 0
+
+        usable_genes = control_mask & self.filtered_genes
+        if not usable_genes.any():
+            raise ValueError(
+                "No genes are available to estimate size factors after applying "
+                "transcript-length and control-gene filters."
+            )
+
+        log_size_factors = np.empty(self.n_obs)
+        for sample_idx in range(self.n_obs):
+            sample_genes = usable_genes & (adjusted_counts[sample_idx] > 0)
+            if not sample_genes.any():
+                raise ValueError(
+                    "At least one sample has no positive counts among the genes "
+                    "available for transcript-length normalization."
+                )
+            log_size_factors[sample_idx] = np.median(
+                np.log(adjusted_counts[sample_idx, sample_genes])
+                - self.logmeans[sample_genes]
+            )
+
+        # estimateNormFactors() in DESeq2 returns a matrix whose gene-wise geometric
+        # means are one. Retain the library-size component separately for backwards
+        # compatibility, while using the full matrix throughout model fitting.
+        size_factors = np.exp(log_size_factors)
+        size_factors /= np.exp(np.mean(np.log(size_factors)))
+        normalization_factors = length_factors * size_factors[:, None]
+        normalization_factors /= np.exp(np.mean(np.log(normalization_factors), axis=0))
+
+        self.obs["size_factors"] = size_factors
+        self.layers["normalization_factors"] = normalization_factors
+        self.layers["normed_counts"] = counts / normalization_factors
 
     @property
     def variables(self):
@@ -459,6 +598,12 @@ class DeseqDataSet(ad.AnnData):
         if "size_factors" not in self.obs:
             raise RuntimeError(
                 "The vst_fit method should be called prior to vst_transform."
+            )
+
+        if counts is not None and "avg_tx_length" in self.layers:
+            raise ValueError(
+                "Transforming external counts with transcript-length normalization "
+                "requires matching transcript lengths, which are not yet supported."
             )
 
         if counts is None:
@@ -652,7 +797,7 @@ class DeseqDataSet(ad.AnnData):
         # If control genes are provided, set a mask where those genes are True
         # This will override self.control_genes
         if control_genes is not None:
-            _control_mask = np.zeros(self.X.shape[1], dtype=bool)
+            _control_mask: np.ndarray = np.zeros(self.X.shape[1], dtype=bool)
 
             # Use AnnData internal indexing to get gene index array
             # Allows bool/int/var_name to be provided
@@ -664,7 +809,21 @@ class DeseqDataSet(ad.AnnData):
         else:
             _control_mask = np.ones(self.X.shape[1], dtype=bool)
 
-        if fit_type == "iterative":
+        if "avg_tx_length" not in self.layers and "normalization_factors" in self.layers:
+            del self.layers["normalization_factors"]
+
+        if "avg_tx_length" in self.layers:
+            if fit_type == "iterative":
+                raise ValueError(
+                    "The iterative size-factor method does not support "
+                    "transcript-length normalization. Use 'ratio' or 'poscounts'."
+                )
+            self._fit_transcript_length_factors(
+                fit_type=fit_type,
+                control_mask=_control_mask,
+            )
+
+        elif fit_type == "iterative":
             self._fit_iterate_size_factors()
 
         elif fit_type == "poscounts":
@@ -752,7 +911,9 @@ class DeseqDataSet(ad.AnnData):
 
         # Convert design_matrix to numpy for speed
         design_matrix = self.obsm["design_matrix"].values
-        size_factors = self.obs["size_factors"].values
+        size_factors = self._get_normalization_factors()
+        if size_factors.ndim == 2:
+            size_factors = size_factors[:, self.non_zero_idx]
 
         # mu_hat is initialized differently depending on the number of different factor
         # groups. If there are as many different factor combinations as design factors
@@ -966,9 +1127,12 @@ class DeseqDataSet(ad.AnnData):
         if not self.quiet:
             print("Fitting LFCs...", file=sys.stderr)
         start = time.time()
+        normalization_factors = self._get_normalization_factors()
+        if normalization_factors.ndim == 2:
+            normalization_factors = normalization_factors[:, self.non_zero_idx]
         mle_lfcs_, mu_, hat_diagonals_, converged_ = self.inference.irls(
             counts=self.X[:, self.non_zero_idx],
-            size_factors=self.obs["size_factors"].values,
+            size_factors=normalization_factors,
             design_matrix=design_matrix,
             disp=self.var.loc[self.var["non_zero"], "dispersions"].values,
             min_mu=self.min_mu,
@@ -1167,8 +1331,11 @@ class DeseqDataSet(ad.AnnData):
             normed_counts,
             self.obsm["design_matrix"].values,
         )
+        normalization_factors = self._get_normalization_factors()
+        if normalization_factors.ndim == 2:
+            normalization_factors = normalization_factors[:, self.non_zero_idx]
         mde = self.inference.fit_moments_dispersions(
-            normed_counts, self.obs["size_factors"]
+            normed_counts, normalization_factors
         )
         alpha_hat = np.minimum(rde, mde)
 
@@ -1342,34 +1509,31 @@ class DeseqDataSet(ad.AnnData):
         self.var["replaced"] = idx.any(axis=0)
 
         if sum(self.var["replaced"] > 0):
-            # Compute replacement counts: trimmed means * size_factors
+            # Compute replacement counts: trimmed means * normalization factors
             self.counts_to_refit = self[:, self.var["replaced"]].copy()
+            normalization_factors = self._get_normalization_factors()
+            if normalization_factors.ndim == 1:
+                normalization_factors = normalization_factors[:, None]
+            else:
+                normalization_factors = normalization_factors[
+                    :, self.var["replaced"].to_numpy()
+                ]
 
-            trim_base_mean = pd.DataFrame(
-                np.asarray(
-                    trimmed_mean(
-                        self.counts_to_refit.X
-                        / self.obs["size_factors"].values[:, None],
-                        trim=0.2,
-                        axis=0,
-                    )
-                ),
-                index=self.counts_to_refit.var_names,
-            )
-
-            replacement_counts = (
-                pd.DataFrame(
-                    trim_base_mean.values * self.obs["size_factors"].values,
-                    index=self.counts_to_refit.var_names,
-                    columns=self.counts_to_refit.obs_names,
+            trim_base_mean = np.asarray(
+                trimmed_mean(
+                    self.counts_to_refit.X / normalization_factors,
+                    trim=0.2,
+                    axis=0,
                 )
-                .astype(int)
-                .T
+            )
+            replacement_counts = np.asarray(
+                trim_base_mean[None, :] * normalization_factors,
+                dtype=int,
             )
 
             self.counts_to_refit.X[
                 self.obs["replaceable"].values[:, None] & idx[:, self.var["replaced"]]
-            ] = replacement_counts.values[
+            ] = replacement_counts[
                 self.obs["replaceable"].values[:, None] & idx[:, self.var["replaced"]]
             ]
 
@@ -1423,11 +1587,16 @@ class DeseqDataSet(ad.AnnData):
             quiet=self.quiet,
         )
 
-        # Use the same size factors
+        # Use the same normalization factors
         sub_dds.obs["size_factors"] = self.counts_to_refit.obs["size_factors"]
-        sub_dds.layers["normed_counts"] = (
-            sub_dds.X / sub_dds.obs["size_factors"].values[:, None]
-        )
+        if "normalization_factors" in self.counts_to_refit.layers:
+            sub_dds.layers["normalization_factors"] = self.counts_to_refit.layers[
+                "normalization_factors"
+            ]
+        normalization_factors = sub_dds._get_normalization_factors()
+        if normalization_factors.ndim == 1:
+            normalization_factors = normalization_factors[:, None]
+        sub_dds.layers["normed_counts"] = sub_dds.X / normalization_factors
 
         # Estimate gene-wise dispersions.
         sub_dds.fit_genewise_dispersions()

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 from formulaic_contrasts import FormulaicContrasts  # type: ignore[import-untyped]
 from scipy.optimize import minimize
+from scipy.sparse import issparse  # type: ignore
 from scipy.special import polygamma  # type: ignore
 from scipy.stats import f  # type: ignore
 from scipy.stats import trim_mean  # type: ignore
@@ -374,6 +375,56 @@ class DeseqDataSet(ad.AnnData):
                 )
             self._validate_transcript_lengths(transcript_lengths_array)
             self.layers["avg_tx_length"] = transcript_lengths_array
+            if adata is not None and transcript_lengths is not None:
+                # Invalidate fitting state derived from copied normalization factors.
+                for column in ("size_factors", "replaceable"):
+                    if column in self.obs:
+                        del self.obs[column]
+                for column in (
+                    "_normed_means",
+                    "non_zero",
+                    "_MoM_dispersions",
+                    "genewise_dispersions",
+                    "vst_genewise_dispersions",
+                    "_genewise_converged",
+                    "fitted_dispersions",
+                    "MAP_dispersions",
+                    "_MAP_converged",
+                    "dispersions",
+                    "_outlier_genes",
+                    "_LFC_converged",
+                    "replaced",
+                    "refitted",
+                    "_pvalue_cooks_outlier",
+                ):
+                    if column in self.var:
+                        del self.var[column]
+                for layer in (
+                    "normalization_factors",
+                    "normed_counts",
+                    "_mu_hat",
+                    "_vst_mu_hat",
+                    "vst_counts",
+                    "cooks",
+                    "replace_cooks",
+                ):
+                    if layer in self.layers:
+                        del self.layers[layer]
+                for key in ("_mu_LFC", "_hat_diagonals"):
+                    if key in self.obsm:
+                        del self.obsm[key]
+                if "LFC" in self.varm:
+                    del self.varm["LFC"]
+                for key in (
+                    "trend_coeffs",
+                    "vst_trend_coeffs",
+                    "mean_disp",
+                    "disp_function_type",
+                    "_squared_logres",
+                    "prior_disp_var",
+                ):
+                    if key in self.uns:
+                        del self.uns[key]
         elif "avg_tx_length" in self.layers:
             stored_lengths = self.layers["avg_tx_length"]
             transcript_lengths_array = (
@@ -896,9 +947,13 @@ class DeseqDataSet(ad.AnnData):
             self._fit_iterate_size_factors()
 
         elif fit_type == "poscounts":
+            counts = (
+                cast(Any, self.X).toarray() if issparse(self.X) else np.asarray(self.X)
+            )
+
             # Calculate logcounts for x > 0 and take the mean for each gene
-            log_counts = np.zeros_like(self.X, dtype=float)
-            np.log(self.X, out=log_counts, where=self.X != 0)
+            log_counts = np.zeros_like(counts, dtype=float)
+            np.log(counts, out=log_counts, where=counts != 0)
             logmeans = log_counts.mean(axis=0)
 
             # Determine which genes are usable (finite logmeans)
@@ -910,18 +965,22 @@ class DeseqDataSet(ad.AnnData):
                 _mask = np.logical_and(_control_mask, x > 0)
                 return np.exp(np.median(np.log(x[_mask]) - logmeans[_mask]))
 
-            sf = np.apply_along_axis(sizeFactor, 1, self.X)
+            sf = np.apply_along_axis(sizeFactor, 1, counts)
             del log_counts
 
             # Normalize size factors to a geometric mean of 1 to match DESeq
             self.obs["size_factors"] = sf / (np.exp(np.mean(np.log(sf))))
             self.layers["normed_counts"] = (
-                self.X / self.obs["size_factors"].values[:, None]
+                counts / self.obs["size_factors"].values[:, None]
             )
             self.logmeans = logmeans
 
         # Test whether it is possible to use median-of-ratios.
-        elif (self.X == 0).any(0).all():
+        elif (
+            (cast(Any, self.X).count_nonzero(axis=0) < self.n_obs).all()
+            if issparse(self.X)
+            else (self.X == 0).any(0).all()
+        ):
             # There is at least a zero for each gene
             warnings.warn(
                 "Every gene contains at least one zero, "
@@ -932,16 +991,17 @@ class DeseqDataSet(ad.AnnData):
             self._fit_iterate_size_factors()
 
         elif self.X is not None:
-            self.logmeans, self.filtered_genes = deseq2_norm_fit(
-                self.X.toarray() if not isinstance(self.X, np.ndarray) else self.X
+            counts = (
+                cast(Any, self.X).toarray() if issparse(self.X) else np.asarray(self.X)
             )
+            self.logmeans, self.filtered_genes = deseq2_norm_fit(counts)
             _control_mask &= self.filtered_genes
 
             (
                 self.layers["normed_counts"],
                 self.obs["size_factors"],
             ) = deseq2_norm_transform(
-                self.X, cast(np.ndarray, self.logmeans), _control_mask
+                counts, cast(np.ndarray, self.logmeans), _control_mask
             )
         else:
             raise ValueError("Counts matrix 'X' is None, cannot fit size factors.")
@@ -1737,9 +1797,13 @@ class DeseqDataSet(ad.AnnData):
             (default: ``0.95``).
 
         """
+        self.logmeans = None
+        self.filtered_genes = None
+        counts = cast(Any, self.X).toarray() if issparse(self.X) else np.asarray(self.X)
+
         # Initialize size factors and normed counts fields
         self.obs["size_factors"] = np.ones(self.n_obs)
-        self.layers["normed_counts"] = self.X
+        self.layers["normed_counts"] = counts
 
         # Reduce the design matrix to an intercept and reconstruct at the end
         self.obsm["design_matrix_buffer"] = self.obsm["design_matrix"].copy()
@@ -1751,7 +1815,7 @@ class DeseqDataSet(ad.AnnData):
         def objective(p):
             sf = np.exp(p - np.mean(p))
             nll = nb_nll(
-                counts=self[:, self.non_zero_genes].X,
+                counts=counts[:, self.non_zero_idx],
                 mu=self[:, self.non_zero_genes].layers["_mu_hat"]
                 / self.obs["size_factors"].values[:, None]
                 * sf[:, None],
@@ -1809,7 +1873,7 @@ class DeseqDataSet(ad.AnnData):
         del self.obsm["design_matrix_buffer"]
 
         # Store normalized counts
-        self.layers["normed_counts"] = self.X / self.obs["size_factors"].values[:, None]
+        self.layers["normed_counts"] = counts / self.obs["size_factors"].values[:, None]
 
     def _check_full_rank_design(self):
         """Check that the design matrix has full column rank."""

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -38,11 +38,10 @@ def _rounded_counts(counts: Any) -> Any:
         return counts.round()
     if isinstance(counts, np.ndarray):
         return np.rint(counts)
-    sparse_counts = cast(Any, counts)
-    if sparse_counts.format in {"csr", "csc"}:
-        rounded = sparse_counts.copy()
+    if counts.format in {"csr", "csc"}:
+        rounded = counts.copy()
     else:
-        rounded = sparse_counts.tocsr()
+        rounded = counts.tocsr()
     rounded.sum_duplicates()
     rounded.data = np.rint(rounded.data)
     rounded.eliminate_zeros()
@@ -356,7 +355,6 @@ class DeseqDataSet(ad.AnnData):
                 )
                 self.uns.update(owned_uns)
             else:
-                # Preserve the existing AnnData initialization behavior.
                 self.__dict__.update(adata.__dict__)
                 # AnnData 0.13 stores X under the None layer key. Detach the
                 # container so assigning self.X does not modify the input AnnData.
@@ -465,12 +463,7 @@ class DeseqDataSet(ad.AnnData):
 
         if preserve_inherited_fit and adata is not None:
             source_design = adata.obsm.get("design_matrix")
-            normalization_control_mask = np.ones(self.n_vars, dtype=bool)
-            if control_genes is not None:
-                normalization_control_mask[:] = False
-                normalization_control_mask[
-                    self._normalize_indices((slice(None), control_genes))[1]
-                ] = True
+            normalization_control_mask = self._make_control_mask(control_genes)
             fit_settings = (
                 ("fit_type", fit_type),
                 ("min_mu", min_mu),
@@ -484,10 +477,7 @@ class DeseqDataSet(ad.AnnData):
                 isinstance(source_design, pd.DataFrame)
                 and cast(pd.DataFrame, self.obsm["design_matrix"]).equals(source_design)
                 and all(
-                    hasattr(adata, attr)
-                    and np.array_equal(
-                        np.asarray(getattr(adata, attr)), np.asarray(value)
-                    )
+                    hasattr(adata, attr) and np.array_equal(getattr(adata, attr), value)
                     for attr, value in fit_settings
                 )
                 and getattr(adata, "_normalization_fit_type", None)
@@ -497,24 +487,15 @@ class DeseqDataSet(ad.AnnData):
                     adata._normalization_control_mask,
                     normalization_control_mask,
                 )
+                and hasattr(adata, "inference")
                 and (
-                    (
-                        inference is None
-                        and hasattr(adata, "inference")
-                        and type(adata.inference) is DefaultInference
-                    )
-                    or (
-                        inference is not None
-                        and hasattr(adata, "inference")
-                        and inference is adata.inference
-                    )
+                    type(adata.inference) is DefaultInference
+                    if inference is None
+                    else inference is adata.inference
                 )
             )
 
-        invalidate_inherited_fit = (
-            adata is not None and has_transcript_lengths and not preserve_inherited_fit
-        )
-        if invalidate_inherited_fit:
+        if adata is not None and has_transcript_lengths and not preserve_inherited_fit:
             # Invalidate fitting state derived from copied normalization factors.
             for column in ("size_factors", "replaceable"):
                 if column in self.obs:
@@ -547,13 +528,10 @@ class DeseqDataSet(ad.AnnData):
                 "cooks",
                 "replace_cooks",
             ):
-                if layer in self.layers:
-                    del self.layers[layer]
+                self.layers.pop(layer, None)
             for key in ("_mu_LFC", "_hat_diagonals"):
-                if key in self.obsm:
-                    del self.obsm[key]
-            if "LFC" in self.varm:
-                del self.varm["LFC"]
+                self.obsm.pop(key, None)
+            self.varm.pop("LFC", None)
             for key in (
                 "trend_coeffs",
                 "vst_trend_coeffs",
@@ -562,8 +540,7 @@ class DeseqDataSet(ad.AnnData):
                 "_squared_logres",
                 "prior_disp_var",
             ):
-                if key in self.uns:
-                    del self.uns[key]
+                self.uns.pop(key, None)
 
         self.min_mu = min_mu
         self.min_disp = min_disp
@@ -624,10 +601,19 @@ class DeseqDataSet(ad.AnnData):
         if (transcript_lengths <= 0).any():
             raise ValueError("transcript_lengths must contain only positive values.")
 
-    def _get_normalization_factors(self) -> np.ndarray:
-        """Return gene-specific factors when present, otherwise sample size factors."""
+    def _make_control_mask(self, control_genes: Any) -> np.ndarray:
+        """Return a gene mask for the selected normalization controls."""
+        if control_genes is None:
+            return np.ones(self.n_vars, dtype=bool)
+        control_mask = np.zeros(self.n_vars, dtype=bool)
+        control_mask[self._normalize_indices((slice(None), control_genes))[1]] = True
+        return control_mask
+
+    def _get_normalization_factors(self, gene_idx: Any = None) -> np.ndarray:
+        """Return normalization factors, optionally restricted to genes."""
         if "normalization_factors" in self.layers:
-            return np.asarray(self.layers["normalization_factors"])
+            factors = np.asarray(self.layers["normalization_factors"])
+            return factors if gene_idx is None else factors[:, gene_idx]
         return self.obs["size_factors"].to_numpy()
 
     def _fit_transcript_length_factors(
@@ -636,9 +622,7 @@ class DeseqDataSet(ad.AnnData):
         control_mask: np.ndarray,
     ) -> None:
         """Fit DESeq2-style normalization factors from average transcript lengths."""
-        counts = np.asarray(
-            cast(Any, self.X).toarray() if hasattr(self.X, "toarray") else self.X
-        )
+        counts = cast(Any, self.X).toarray() if issparse(self.X) else np.asarray(self.X)
         transcript_lengths = np.asarray(self.layers["avg_tx_length"])
 
         # DESeq2 centers each gene's average transcript lengths around a geometric
@@ -1008,20 +992,7 @@ class DeseqDataSet(ad.AnnData):
                         " DeseqDataSet initialization"
                     )
 
-        # If control genes are provided, set a mask where those genes are True
-        # This will override self.control_genes
-        if control_genes is not None:
-            _control_mask: np.ndarray = np.zeros(self.X.shape[1], dtype=bool)
-
-            # Use AnnData internal indexing to get gene index array
-            # Allows bool/int/var_name to be provided
-            _control_mask[self._normalize_indices((slice(None), control_genes))[1]] = (
-                True
-            )
-
-        # Otherwise mask all genes to be True
-        else:
-            _control_mask = np.ones(self.X.shape[1], dtype=bool)
+        _control_mask = self._make_control_mask(control_genes)
         normalization_control_mask = _control_mask.copy()
 
         if "avg_tx_length" not in self.layers and "normalization_factors" in self.layers:
@@ -1137,9 +1108,7 @@ class DeseqDataSet(ad.AnnData):
 
         # Convert design_matrix to numpy for speed
         design_matrix = self.obsm["design_matrix"].values
-        size_factors = self._get_normalization_factors()
-        if size_factors.ndim == 2:
-            size_factors = size_factors[:, self.non_zero_idx]
+        size_factors = self._get_normalization_factors(self.non_zero_idx)
 
         # mu_hat is initialized differently depending on the number of different factor
         # groups. If there are as many different factor combinations as design factors
@@ -1353,9 +1322,7 @@ class DeseqDataSet(ad.AnnData):
         if not self.quiet:
             print("Fitting LFCs...", file=sys.stderr)
         start = time.time()
-        normalization_factors = self._get_normalization_factors()
-        if normalization_factors.ndim == 2:
-            normalization_factors = normalization_factors[:, self.non_zero_idx]
+        normalization_factors = self._get_normalization_factors(self.non_zero_idx)
         mle_lfcs_, mu_, hat_diagonals_, converged_ = self.inference.irls(
             counts=self.X[:, self.non_zero_idx],
             size_factors=normalization_factors,
@@ -1414,7 +1381,7 @@ class DeseqDataSet(ad.AnnData):
         counts = self.X[:, self.non_zero_idx]
         if hasattr(counts, "tocoo"):
             counts = counts.tocoo()
-            squared_pearson_res = -self.obsm["_mu_LFC"].copy()
+            squared_pearson_res = -self.obsm["_mu_LFC"]
             np.add.at(squared_pearson_res, (counts.row, counts.col), counts.data)
         else:
             squared_pearson_res = counts - self.obsm["_mu_LFC"]
@@ -1509,11 +1476,10 @@ class DeseqDataSet(ad.AnnData):
         pos = np.asarray(self.layers["cooks"][:, cooks_outlier].argmax(0)).ravel()
         for gene_idx, sample_idx in zip(np.flatnonzero(cooks_outlier), pos, strict=True):
             gene_counts = (
-                self.X[:, [gene_idx]] if issparse(self.X) else self.X[:, gene_idx]
+                cast(Any, self.X)[:, [gene_idx]].toarray().ravel()
+                if issparse(self.X)
+                else np.asarray(self.X[:, gene_idx]).ravel()
             )
-            if hasattr(gene_counts, "toarray"):
-                gene_counts = gene_counts.toarray()
-            gene_counts = np.asarray(gene_counts).ravel()
             cooks_outlier[gene_idx] = (gene_counts > gene_counts[sample_idx]).sum() < 3
 
         if self.low_memory:
@@ -1567,9 +1533,7 @@ class DeseqDataSet(ad.AnnData):
             normed_counts,
             self.obsm["design_matrix"].values,
         )
-        normalization_factors = self._get_normalization_factors()
-        if normalization_factors.ndim == 2:
-            normalization_factors = normalization_factors[:, self.non_zero_idx]
+        normalization_factors = self._get_normalization_factors(self.non_zero_idx)
         mde = self.inference.fit_moments_dispersions(
             normed_counts, normalization_factors
         )
@@ -1749,13 +1713,11 @@ class DeseqDataSet(ad.AnnData):
             self.counts_to_refit = self[:, self.var["replaced"]].copy()
             if hasattr(self.counts_to_refit.X, "toarray"):
                 self.counts_to_refit.X = self.counts_to_refit.X.toarray()
-            normalization_factors = self._get_normalization_factors()
+            normalization_factors = self._get_normalization_factors(
+                self.var["replaced"].to_numpy()
+            )
             if normalization_factors.ndim == 1:
                 normalization_factors = normalization_factors[:, None]
-            else:
-                normalization_factors = normalization_factors[
-                    :, self.var["replaced"].to_numpy()
-                ]
 
             trim_base_mean = np.asarray(
                 trimmed_mean(

--- a/pydeseq2/dds.py
+++ b/pydeseq2/dds.py
@@ -38,7 +38,11 @@ def _rounded_counts(counts: Any) -> Any:
         return counts.round()
     if isinstance(counts, np.ndarray):
         return np.rint(counts)
-    rounded = counts.copy()
+    sparse_counts = cast(Any, counts)
+    if sparse_counts.format in {"csr", "csc"}:
+        rounded = sparse_counts.copy()
+    else:
+        rounded = sparse_counts.tocsr()
     rounded.sum_duplicates()
     rounded.data = np.rint(rounded.data)
     rounded.eliminate_zeros()
@@ -269,6 +273,7 @@ class DeseqDataSet(ad.AnnData):
         has_transcript_lengths = (
             selected_transcript_lengths is not None or has_stored_transcript_lengths
         )
+        preserve_inherited_fit = False
         if adata is not None:
             has_pytximport_fields = (
                 "length" in adata.obsm and "counts_from_abundance" in adata.uns
@@ -290,6 +295,12 @@ class DeseqDataSet(ad.AnnData):
             ):
                 selected_transcript_lengths = adata.obsm["length"]
 
+            preserve_inherited_fit = (
+                selected_transcript_lengths is None
+                and has_stored_transcript_lengths
+                and "normalization_factors" in adata.layers
+            )
+
             if adata.isbacked:
                 raise ValueError(
                     "DeseqDataSet requires an in-memory AnnData object. Call "
@@ -305,9 +316,17 @@ class DeseqDataSet(ad.AnnData):
                 warnings.warn(
                     "adata was provided; ignoring metadata.", UserWarning, stacklevel=2
                 )
-            prepared_counts: Any = (
-                _rounded_counts(adata.X) if has_transcript_lengths else adata.X
-            )
+            prepared_counts: Any = adata.X
+            if has_transcript_lengths:
+                prepared_counts = _rounded_counts(prepared_counts)
+            elif issparse(prepared_counts):
+                sparse_counts = cast(Any, prepared_counts)
+                if sparse_counts.format not in {"csr", "csc"}:
+                    prepared_counts = sparse_counts.tocsr()
+                    prepared_counts.sum_duplicates()
+                elif not sparse_counts.has_canonical_format:
+                    prepared_counts = sparse_counts.copy()
+                    prepared_counts.sum_duplicates()
             # Test counts before going further
             test_valid_counts(prepared_counts)
             integer_counts = prepared_counts.astype(int)
@@ -339,6 +358,10 @@ class DeseqDataSet(ad.AnnData):
             else:
                 # Preserve the existing AnnData initialization behavior.
                 self.__dict__.update(adata.__dict__)
+                # AnnData 0.13 stores X under the None layer key. Detach the
+                # container so assigning self.X does not modify the input AnnData.
+                if None in self.__dict__.get("_layers", {}):
+                    self.__dict__["_layers"] = self.__dict__["_layers"].copy()
                 self.X = integer_counts
         elif counts is not None and metadata is not None:
             expected_length_index = counts.index
@@ -375,56 +398,6 @@ class DeseqDataSet(ad.AnnData):
                 )
             self._validate_transcript_lengths(transcript_lengths_array)
             self.layers["avg_tx_length"] = transcript_lengths_array
-            if adata is not None and transcript_lengths is not None:
-                # Invalidate fitting state derived from copied normalization factors.
-                for column in ("size_factors", "replaceable"):
-                    if column in self.obs:
-                        del self.obs[column]
-                for column in (
-                    "_normed_means",
-                    "non_zero",
-                    "_MoM_dispersions",
-                    "genewise_dispersions",
-                    "vst_genewise_dispersions",
-                    "_genewise_converged",
-                    "fitted_dispersions",
-                    "MAP_dispersions",
-                    "_MAP_converged",
-                    "dispersions",
-                    "_outlier_genes",
-                    "_LFC_converged",
-                    "replaced",
-                    "refitted",
-                    "_pvalue_cooks_outlier",
-                ):
-                    if column in self.var:
-                        del self.var[column]
-                for layer in (
-                    "normalization_factors",
-                    "normed_counts",
-                    "_mu_hat",
-                    "_vst_mu_hat",
-                    "vst_counts",
-                    "cooks",
-                    "replace_cooks",
-                ):
-                    if layer in self.layers:
-                        del self.layers[layer]
-                for key in ("_mu_LFC", "_hat_diagonals"):
-                    if key in self.obsm:
-                        del self.obsm[key]
-                if "LFC" in self.varm:
-                    del self.varm["LFC"]
-                for key in (
-                    "trend_coeffs",
-                    "vst_trend_coeffs",
-                    "mean_disp",
-                    "disp_function_type",
-                    "_squared_logres",
-                    "prior_disp_var",
-                ):
-                    if key in self.uns:
-                        del self.uns[key]
         elif "avg_tx_length" in self.layers:
             stored_lengths = self.layers["avg_tx_length"]
             transcript_lengths_array = (
@@ -490,6 +463,108 @@ class DeseqDataSet(ad.AnnData):
         # Check that the design matrix has full rank
         self._check_full_rank_design()
 
+        if preserve_inherited_fit and adata is not None:
+            source_design = adata.obsm.get("design_matrix")
+            normalization_control_mask = np.ones(self.n_vars, dtype=bool)
+            if control_genes is not None:
+                normalization_control_mask[:] = False
+                normalization_control_mask[
+                    self._normalize_indices((slice(None), control_genes))[1]
+                ] = True
+            fit_settings = (
+                ("fit_type", fit_type),
+                ("min_mu", min_mu),
+                ("min_disp", min_disp),
+                ("max_disp", np.maximum(max_disp, self.n_obs)),
+                ("refit_cooks", refit_cooks),
+                ("min_replicates", min_replicates),
+                ("beta_tol", beta_tol),
+            )
+            preserve_inherited_fit = (
+                isinstance(source_design, pd.DataFrame)
+                and cast(pd.DataFrame, self.obsm["design_matrix"]).equals(source_design)
+                and all(
+                    hasattr(adata, attr)
+                    and np.array_equal(
+                        np.asarray(getattr(adata, attr)), np.asarray(value)
+                    )
+                    for attr, value in fit_settings
+                )
+                and getattr(adata, "_normalization_fit_type", None)
+                == size_factors_fit_type
+                and hasattr(adata, "_normalization_control_mask")
+                and np.array_equal(
+                    adata._normalization_control_mask,
+                    normalization_control_mask,
+                )
+                and (
+                    (
+                        inference is None
+                        and hasattr(adata, "inference")
+                        and type(adata.inference) is DefaultInference
+                    )
+                    or (
+                        inference is not None
+                        and hasattr(adata, "inference")
+                        and inference is adata.inference
+                    )
+                )
+            )
+
+        invalidate_inherited_fit = (
+            adata is not None and has_transcript_lengths and not preserve_inherited_fit
+        )
+        if invalidate_inherited_fit:
+            # Invalidate fitting state derived from copied normalization factors.
+            for column in ("size_factors", "replaceable"):
+                if column in self.obs:
+                    del self.obs[column]
+            for column in (
+                "_normed_means",
+                "non_zero",
+                "_MoM_dispersions",
+                "genewise_dispersions",
+                "vst_genewise_dispersions",
+                "_genewise_converged",
+                "fitted_dispersions",
+                "MAP_dispersions",
+                "_MAP_converged",
+                "dispersions",
+                "_outlier_genes",
+                "_LFC_converged",
+                "replaced",
+                "refitted",
+                "_pvalue_cooks_outlier",
+            ):
+                if column in self.var:
+                    del self.var[column]
+            for layer in (
+                "normalization_factors",
+                "normed_counts",
+                "_mu_hat",
+                "_vst_mu_hat",
+                "vst_counts",
+                "cooks",
+                "replace_cooks",
+            ):
+                if layer in self.layers:
+                    del self.layers[layer]
+            for key in ("_mu_LFC", "_hat_diagonals"):
+                if key in self.obsm:
+                    del self.obsm[key]
+            if "LFC" in self.varm:
+                del self.varm["LFC"]
+            for key in (
+                "trend_coeffs",
+                "vst_trend_coeffs",
+                "mean_disp",
+                "disp_function_type",
+                "_squared_logres",
+                "prior_disp_var",
+            ):
+                if key in self.uns:
+                    del self.uns[key]
+
         self.min_mu = min_mu
         self.min_disp = min_disp
         self.max_disp = np.maximum(max_disp, self.n_obs)
@@ -517,6 +592,25 @@ class DeseqDataSet(ad.AnnData):
 
         # Initialize the inference object.
         self.inference = inference or DefaultInference(n_cpus=n_cpus)
+
+        if preserve_inherited_fit and adata is not None:
+            if "LFC" in self.varm:
+                self.varm["LFC"] = self.varm["LFC"].copy()
+
+            self._normalization_fit_type = adata._normalization_fit_type
+            self._normalization_control_mask = adata._normalization_control_mask.copy()
+
+            for attr in (
+                "non_zero_idx",
+                "non_zero_genes",
+                "counts_to_refit",
+                "new_all_zeroes_genes",
+            ):
+                if hasattr(adata, attr):
+                    setattr(self, attr, getattr(adata, attr).copy())
+
+            if hasattr(adata, "vst_fit_type"):
+                self.vst_fit_type = adata.vst_fit_type
 
     def _validate_transcript_lengths(self, transcript_lengths: np.ndarray) -> None:
         """Validate a sample-by-gene average transcript-length matrix."""
@@ -928,6 +1022,7 @@ class DeseqDataSet(ad.AnnData):
         # Otherwise mask all genes to be True
         else:
             _control_mask = np.ones(self.X.shape[1], dtype=bool)
+        normalization_control_mask = _control_mask.copy()
 
         if "avg_tx_length" not in self.layers and "normalization_factors" in self.layers:
             del self.layers["normalization_factors"]
@@ -977,7 +1072,7 @@ class DeseqDataSet(ad.AnnData):
 
         # Test whether it is possible to use median-of-ratios.
         elif (
-            (cast(Any, self.X).count_nonzero(axis=0) < self.n_obs).all()
+            (np.asarray((cast(Any, self.X) != 0).sum(axis=0)).ravel() < self.n_obs).all()
             if issparse(self.X)
             else (self.X == 0).any(0).all()
         ):
@@ -1008,6 +1103,8 @@ class DeseqDataSet(ad.AnnData):
 
         end = time.time()
         self.var["_normed_means"] = self.layers["normed_counts"].mean(axis=0)
+        self._normalization_fit_type = fit_type
+        self._normalization_control_mask = normalization_control_mask
 
         if not self.quiet:
             print(f"... done in {end - start:.2f} seconds.\n", file=sys.stderr)
@@ -1411,7 +1508,9 @@ class DeseqDataSet(ad.AnnData):
 
         pos = np.asarray(self.layers["cooks"][:, cooks_outlier].argmax(0)).ravel()
         for gene_idx, sample_idx in zip(np.flatnonzero(cooks_outlier), pos, strict=True):
-            gene_counts = self.X[:, gene_idx]
+            gene_counts = (
+                self.X[:, [gene_idx]] if issparse(self.X) else self.X[:, gene_idx]
+            )
             if hasattr(gene_counts, "toarray"):
                 gene_counts = gene_counts.toarray()
             gene_counts = np.asarray(gene_counts).ravel()

--- a/pydeseq2/default_inference.py
+++ b/pydeseq2/default_inference.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import Literal
 from typing import cast
 
@@ -7,25 +8,27 @@ from joblib import Parallel  # type: ignore
 from joblib import delayed
 from joblib import parallel_backend
 from scipy.optimize import minimize  # type: ignore
-from scipy.sparse import issparse  # type: ignore
 
 from pydeseq2 import inference
 from pydeseq2 import utils
 
 
+def _column_sliceable_counts(counts: inference.CountMatrix) -> Any:
+    """Use CSC storage for efficient repeated sparse column slices."""
+    if isinstance(counts, np.ndarray):
+        return counts
+    return cast(Any, counts).tocsc(copy=False)
+
+
 def _gene_factors(factors: np.ndarray, gene_idx: int) -> np.ndarray:
-    """Select one gene's factors from a sample vector or sample-by-gene matrix."""
-    if factors.ndim == 2:
-        return factors[:, gene_idx]
-    return factors
+    return factors[:, gene_idx] if factors.ndim == 2 else factors
 
 
-def _gene_counts(counts: np.ndarray, gene_idx: int) -> np.ndarray:
+def _gene_counts(counts: Any, gene_idx: int) -> np.ndarray:
     """Return one gene's counts as a dense sample vector."""
-    column = counts[:, [gene_idx]] if issparse(counts) else counts[:, gene_idx]
-    if hasattr(column, "toarray"):
-        column = column.toarray()
-    return np.asarray(column).ravel()
+    if isinstance(counts, np.ndarray):
+        return np.asarray(counts[:, gene_idx]).ravel()
+    return counts[:, [gene_idx]].toarray().ravel()
 
 
 class DefaultInference(inference.Inference):
@@ -79,10 +82,7 @@ class DefaultInference(inference.Inference):
         design_matrix: np.ndarray,
         min_mu: float,
     ) -> np.ndarray:
-        counts = cast(
-            np.ndarray,
-            counts.tocsc(copy=False) if hasattr(counts, "tocsc") else counts,
-        )
+        column_counts = _column_sliceable_counts(counts)
         with parallel_backend(self._backend, inner_max_num_threads=1):
             mu_hat_ = np.array(
                 Parallel(
@@ -91,12 +91,12 @@ class DefaultInference(inference.Inference):
                     batch_size=self._batch_size,
                 )(
                     delayed(utils.fit_lin_mu)(
-                        counts=_gene_counts(counts, i),
+                        counts=_gene_counts(column_counts, i),
                         size_factors=_gene_factors(size_factors, i),
                         design_matrix=design_matrix,
                         min_mu=min_mu,
                     )
-                    for i in range(counts.shape[1])
+                    for i in range(column_counts.shape[1])
                 )
             )
         return mu_hat_.T
@@ -114,10 +114,7 @@ class DefaultInference(inference.Inference):
         optimizer: Literal["BFGS", "L-BFGS-B"] = "L-BFGS-B",
         maxiter: int = 250,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-        counts = cast(
-            np.ndarray,
-            counts.tocsc(copy=False) if hasattr(counts, "tocsc") else counts,
-        )
+        column_counts = _column_sliceable_counts(counts)
         with parallel_backend(self._backend, inner_max_num_threads=1):
             res = Parallel(
                 n_jobs=self.n_cpus,
@@ -125,7 +122,7 @@ class DefaultInference(inference.Inference):
                 batch_size=self._batch_size,
             )(
                 delayed(utils.irls_solver)(
-                    counts=_gene_counts(counts, i),
+                    counts=_gene_counts(column_counts, i),
                     size_factors=_gene_factors(size_factors, i),
                     design_matrix=design_matrix,
                     disp=disp[i],
@@ -136,7 +133,7 @@ class DefaultInference(inference.Inference):
                     optimizer=optimizer,
                     maxiter=maxiter,
                 )
-                for i in range(counts.shape[1])
+                for i in range(column_counts.shape[1])
             )
         res = zip(*res, strict=False)
         MLE_lfcs_, mu_hat_, hat_diagonals_, converged_ = (np.array(m) for m in res)
@@ -161,10 +158,7 @@ class DefaultInference(inference.Inference):
         prior_reg: bool = False,
         optimizer: Literal["BFGS", "L-BFGS-B"] = "L-BFGS-B",
     ) -> tuple[np.ndarray, np.ndarray]:
-        counts = cast(
-            np.ndarray,
-            counts.tocsc(copy=False) if hasattr(counts, "tocsc") else counts,
-        )
+        column_counts = _column_sliceable_counts(counts)
         with parallel_backend(self._backend, inner_max_num_threads=1):
             res = Parallel(
                 n_jobs=self.n_cpus,
@@ -172,7 +166,7 @@ class DefaultInference(inference.Inference):
                 batch_size=self._batch_size,
             )(
                 delayed(utils.fit_alpha_mle)(
-                    counts=_gene_counts(counts, i),
+                    counts=_gene_counts(column_counts, i),
                     design_matrix=design_matrix,
                     mu=mu[:, i],
                     alpha_hat=alpha_hat[i],
@@ -183,7 +177,7 @@ class DefaultInference(inference.Inference):
                     prior_reg=prior_reg,
                     optimizer=optimizer,
                 )
-                for i in range(counts.shape[1])
+                for i in range(column_counts.shape[1])
             )
         res = zip(*res, strict=False)
         dispersions_, l_bfgs_b_converged_ = (np.array(m) for m in res)
@@ -269,12 +263,8 @@ class DefaultInference(inference.Inference):
         optimizer: str,
         shrink_index: int,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        counts = cast(
-            np.ndarray,
-            counts.tocsc(copy=False) if hasattr(counts, "tocsc") else counts,
-        )
+        column_counts = _column_sliceable_counts(counts)
         with parallel_backend(self._backend, inner_max_num_threads=1):
-            num_genes = counts.shape[1]
             res = Parallel(
                 n_jobs=self.n_cpus,
                 verbose=self._joblib_verbosity,
@@ -282,7 +272,7 @@ class DefaultInference(inference.Inference):
             )(
                 delayed(utils.nbinomGLM)(
                     design_matrix=design_matrix,
-                    counts=_gene_counts(counts, i),
+                    counts=_gene_counts(column_counts, i),
                     size=size[i],
                     offset=_gene_factors(offset, i),
                     prior_no_shrink_scale=prior_no_shrink_scale,
@@ -290,7 +280,7 @@ class DefaultInference(inference.Inference):
                     optimizer=optimizer,
                     shrink_index=shrink_index,
                 )
-                for i in range(num_genes)
+                for i in range(column_counts.shape[1])
             )
         res = zip(*res, strict=False)
         lfcs, inv_hessians, l_bfgs_b_converged_ = (np.array(m) for m in res)

--- a/pydeseq2/default_inference.py
+++ b/pydeseq2/default_inference.py
@@ -1,4 +1,5 @@
 from typing import Literal
+from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -72,12 +73,15 @@ class DefaultInference(inference.Inference):
 
     def lin_reg_mu(  # noqa: D102
         self,
-        counts: np.ndarray,
+        counts: inference.CountMatrix,
         size_factors: np.ndarray,
         design_matrix: np.ndarray,
         min_mu: float,
     ) -> np.ndarray:
-        counts = counts.tocsc(copy=False) if hasattr(counts, "tocsc") else counts
+        counts = cast(
+            np.ndarray,
+            counts.tocsc(copy=False) if hasattr(counts, "tocsc") else counts,
+        )
         with parallel_backend(self._backend, inner_max_num_threads=1):
             mu_hat_ = np.array(
                 Parallel(
@@ -98,7 +102,7 @@ class DefaultInference(inference.Inference):
 
     def irls(  # noqa: D102
         self,
-        counts: np.ndarray,
+        counts: inference.CountMatrix,
         size_factors: np.ndarray,
         design_matrix: np.ndarray,
         disp: np.ndarray,
@@ -109,7 +113,10 @@ class DefaultInference(inference.Inference):
         optimizer: Literal["BFGS", "L-BFGS-B"] = "L-BFGS-B",
         maxiter: int = 250,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-        counts = counts.tocsc(copy=False) if hasattr(counts, "tocsc") else counts
+        counts = cast(
+            np.ndarray,
+            counts.tocsc(copy=False) if hasattr(counts, "tocsc") else counts,
+        )
         with parallel_backend(self._backend, inner_max_num_threads=1):
             res = Parallel(
                 n_jobs=self.n_cpus,
@@ -142,7 +149,7 @@ class DefaultInference(inference.Inference):
 
     def alpha_mle(  # noqa: D102
         self,
-        counts: np.ndarray,
+        counts: inference.CountMatrix,
         design_matrix: np.ndarray,
         mu: np.ndarray,
         alpha_hat: np.ndarray,
@@ -153,7 +160,10 @@ class DefaultInference(inference.Inference):
         prior_reg: bool = False,
         optimizer: Literal["BFGS", "L-BFGS-B"] = "L-BFGS-B",
     ) -> tuple[np.ndarray, np.ndarray]:
-        counts = counts.tocsc(copy=False) if hasattr(counts, "tocsc") else counts
+        counts = cast(
+            np.ndarray,
+            counts.tocsc(copy=False) if hasattr(counts, "tocsc") else counts,
+        )
         with parallel_backend(self._backend, inner_max_num_threads=1):
             res = Parallel(
                 n_jobs=self.n_cpus,
@@ -250,7 +260,7 @@ class DefaultInference(inference.Inference):
     def lfc_shrink_nbinom_glm(  # noqa: D102
         self,
         design_matrix: np.ndarray,
-        counts: np.ndarray,
+        counts: inference.CountMatrix,
         size: np.ndarray,
         offset: np.ndarray,
         prior_no_shrink_scale: float,
@@ -258,7 +268,10 @@ class DefaultInference(inference.Inference):
         optimizer: str,
         shrink_index: int,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        counts = counts.tocsc(copy=False) if hasattr(counts, "tocsc") else counts
+        counts = cast(
+            np.ndarray,
+            counts.tocsc(copy=False) if hasattr(counts, "tocsc") else counts,
+        )
         with parallel_backend(self._backend, inner_max_num_threads=1):
             num_genes = counts.shape[1]
             res = Parallel(

--- a/pydeseq2/default_inference.py
+++ b/pydeseq2/default_inference.py
@@ -7,6 +7,7 @@ from joblib import Parallel  # type: ignore
 from joblib import delayed
 from joblib import parallel_backend
 from scipy.optimize import minimize  # type: ignore
+from scipy.sparse import issparse  # type: ignore
 
 from pydeseq2 import inference
 from pydeseq2 import utils
@@ -21,7 +22,7 @@ def _gene_factors(factors: np.ndarray, gene_idx: int) -> np.ndarray:
 
 def _gene_counts(counts: np.ndarray, gene_idx: int) -> np.ndarray:
     """Return one gene's counts as a dense sample vector."""
-    column = counts[:, gene_idx]
+    column = counts[:, [gene_idx]] if issparse(counts) else counts[:, gene_idx]
     if hasattr(column, "toarray"):
         column = column.toarray()
     return np.asarray(column).ravel()

--- a/pydeseq2/default_inference.py
+++ b/pydeseq2/default_inference.py
@@ -11,6 +11,13 @@ from pydeseq2 import inference
 from pydeseq2 import utils
 
 
+def _gene_factors(factors: np.ndarray, gene_idx: int) -> np.ndarray:
+    """Select one gene's factors from a sample vector or sample-by-gene matrix."""
+    if factors.ndim == 2:
+        return factors[:, gene_idx]
+    return factors
+
+
 class DefaultInference(inference.Inference):
     """Default DESeq2-related inference methods, using scipy/sklearn/numpy.
 
@@ -71,7 +78,7 @@ class DefaultInference(inference.Inference):
                 )(
                     delayed(utils.fit_lin_mu)(
                         counts=counts[:, i],
-                        size_factors=size_factors,
+                        size_factors=_gene_factors(size_factors, i),
                         design_matrix=design_matrix,
                         min_mu=min_mu,
                     )
@@ -101,7 +108,7 @@ class DefaultInference(inference.Inference):
             )(
                 delayed(utils.irls_solver)(
                     counts=counts[:, i],
-                    size_factors=size_factors,
+                    size_factors=_gene_factors(size_factors, i),
                     design_matrix=design_matrix,
                     disp=disp[i],
                     min_mu=min_mu,
@@ -251,7 +258,7 @@ class DefaultInference(inference.Inference):
                     design_matrix=design_matrix,
                     counts=counts[:, i],
                     size=size[i],
-                    offset=offset,
+                    offset=_gene_factors(offset, i),
                     prior_no_shrink_scale=prior_no_shrink_scale,
                     prior_scale=prior_scale,
                     optimizer=optimizer,

--- a/pydeseq2/default_inference.py
+++ b/pydeseq2/default_inference.py
@@ -18,6 +18,14 @@ def _gene_factors(factors: np.ndarray, gene_idx: int) -> np.ndarray:
     return factors
 
 
+def _gene_counts(counts: np.ndarray, gene_idx: int) -> np.ndarray:
+    """Return one gene's counts as a dense sample vector."""
+    column = counts[:, gene_idx]
+    if hasattr(column, "toarray"):
+        column = column.toarray()
+    return np.asarray(column).ravel()
+
+
 class DefaultInference(inference.Inference):
     """Default DESeq2-related inference methods, using scipy/sklearn/numpy.
 
@@ -69,6 +77,7 @@ class DefaultInference(inference.Inference):
         design_matrix: np.ndarray,
         min_mu: float,
     ) -> np.ndarray:
+        counts = counts.tocsc(copy=False) if hasattr(counts, "tocsc") else counts
         with parallel_backend(self._backend, inner_max_num_threads=1):
             mu_hat_ = np.array(
                 Parallel(
@@ -77,7 +86,7 @@ class DefaultInference(inference.Inference):
                     batch_size=self._batch_size,
                 )(
                     delayed(utils.fit_lin_mu)(
-                        counts=counts[:, i],
+                        counts=_gene_counts(counts, i),
                         size_factors=_gene_factors(size_factors, i),
                         design_matrix=design_matrix,
                         min_mu=min_mu,
@@ -100,6 +109,7 @@ class DefaultInference(inference.Inference):
         optimizer: Literal["BFGS", "L-BFGS-B"] = "L-BFGS-B",
         maxiter: int = 250,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        counts = counts.tocsc(copy=False) if hasattr(counts, "tocsc") else counts
         with parallel_backend(self._backend, inner_max_num_threads=1):
             res = Parallel(
                 n_jobs=self.n_cpus,
@@ -107,7 +117,7 @@ class DefaultInference(inference.Inference):
                 batch_size=self._batch_size,
             )(
                 delayed(utils.irls_solver)(
-                    counts=counts[:, i],
+                    counts=_gene_counts(counts, i),
                     size_factors=_gene_factors(size_factors, i),
                     design_matrix=design_matrix,
                     disp=disp[i],
@@ -143,6 +153,7 @@ class DefaultInference(inference.Inference):
         prior_reg: bool = False,
         optimizer: Literal["BFGS", "L-BFGS-B"] = "L-BFGS-B",
     ) -> tuple[np.ndarray, np.ndarray]:
+        counts = counts.tocsc(copy=False) if hasattr(counts, "tocsc") else counts
         with parallel_backend(self._backend, inner_max_num_threads=1):
             res = Parallel(
                 n_jobs=self.n_cpus,
@@ -150,7 +161,7 @@ class DefaultInference(inference.Inference):
                 batch_size=self._batch_size,
             )(
                 delayed(utils.fit_alpha_mle)(
-                    counts=counts[:, i],
+                    counts=_gene_counts(counts, i),
                     design_matrix=design_matrix,
                     mu=mu[:, i],
                     alpha_hat=alpha_hat[i],
@@ -247,6 +258,7 @@ class DefaultInference(inference.Inference):
         optimizer: str,
         shrink_index: int,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        counts = counts.tocsc(copy=False) if hasattr(counts, "tocsc") else counts
         with parallel_backend(self._backend, inner_max_num_threads=1):
             num_genes = counts.shape[1]
             res = Parallel(
@@ -256,7 +268,7 @@ class DefaultInference(inference.Inference):
             )(
                 delayed(utils.nbinomGLM)(
                     design_matrix=design_matrix,
-                    counts=counts[:, i],
+                    counts=_gene_counts(counts, i),
                     size=size[i],
                     offset=_gene_factors(offset, i),
                     prior_no_shrink_scale=prior_no_shrink_scale,

--- a/pydeseq2/ds.py
+++ b/pydeseq2/ds.py
@@ -384,10 +384,7 @@ class DeseqStats:
 
         design_matrix = self.design_matrix.values
         size = 1.0 / self.dds.var["dispersions"].values
-        normalization_factors = self.dds._get_normalization_factors()
-        if normalization_factors.ndim == 2:
-            normalization_factors = normalization_factors[:, self.dds.non_zero_idx]
-        offset = np.log(normalization_factors)
+        offset = np.log(self.dds._get_normalization_factors(self.dds.non_zero_idx))
 
         # Set priors
         prior_no_shrink_scale = 15

--- a/pydeseq2/ds.py
+++ b/pydeseq2/ds.py
@@ -317,11 +317,10 @@ class DeseqStats:
                     file=sys.stderr,
                 )
 
-        mu = (
-            np.exp(self.design_matrix @ self.LFC.T)
-            .multiply(self.dds.obs["size_factors"], 0)
-            .values
-        )
+        normalization_factors = self.dds._get_normalization_factors()
+        if normalization_factors.ndim == 1:
+            normalization_factors = normalization_factors[:, None]
+        mu = np.exp(self.design_matrix @ self.LFC.T).to_numpy() * normalization_factors
 
         # Set regularization factors.
         if self.prior_LFC_var is not None:
@@ -385,7 +384,10 @@ class DeseqStats:
 
         design_matrix = self.design_matrix.values
         size = 1.0 / self.dds.var["dispersions"].values
-        offset = np.log(self.dds.obs["size_factors"]).values
+        normalization_factors = self.dds._get_normalization_factors()
+        if normalization_factors.ndim == 2:
+            normalization_factors = normalization_factors[:, self.dds.non_zero_idx]
+        offset = np.log(normalization_factors)
 
         # Set priors
         prior_no_shrink_scale = 15

--- a/pydeseq2/inference.py
+++ b/pydeseq2/inference.py
@@ -1,13 +1,14 @@
 from abc import ABC
 from abc import abstractmethod
 from typing import Literal
+from typing import TypeAlias
 
 import numpy as np
 import pandas as pd
 from scipy.sparse import sparray
 from scipy.sparse import spmatrix
 
-CountMatrix = np.ndarray | spmatrix | sparray
+CountMatrix: TypeAlias = np.ndarray | spmatrix | sparray
 
 
 class Inference(ABC):

--- a/pydeseq2/inference.py
+++ b/pydeseq2/inference.py
@@ -27,7 +27,8 @@ class Inference(ABC):
             Raw counts.
 
         size_factors : ndarray
-            Sample-wise scaling factors (obtained from median-of-ratios).
+            Sample-wise scaling factors, or sample-by-gene normalization factors
+            (obtained from median-of-ratios and optional gene-specific offsets).
 
         design_matrix : ndarray
             Design matrix.
@@ -66,7 +67,8 @@ class Inference(ABC):
             Raw counts.
 
         size_factors : ndarray
-            Sample-wise scaling factors (obtained from median-of-ratios).
+            Sample-wise scaling factors, or sample-by-gene normalization factors
+            (obtained from median-of-ratios and optional gene-specific offsets).
 
         design_matrix : ndarray
             Design matrix.

--- a/pydeseq2/inference.py
+++ b/pydeseq2/inference.py
@@ -4,6 +4,10 @@ from typing import Literal
 
 import numpy as np
 import pandas as pd
+from scipy.sparse import sparray
+from scipy.sparse import spmatrix
+
+CountMatrix = np.ndarray | spmatrix | sparray
 
 
 class Inference(ABC):
@@ -12,7 +16,7 @@ class Inference(ABC):
     @abstractmethod
     def lin_reg_mu(
         self,
-        counts: np.ndarray,
+        counts: CountMatrix,
         size_factors: np.ndarray,
         design_matrix: np.ndarray,
         min_mu: float,
@@ -23,12 +27,14 @@ class Inference(ABC):
 
         Parameters
         ----------
-        counts : ndarray
-            Raw counts.
+        counts : ndarray or scipy.sparse.spmatrix or scipy.sparse.sparray
+            Raw count matrix.
 
         size_factors : ndarray
-            Sample-wise scaling factors, or sample-by-gene normalization factors
-            (obtained from median-of-ratios and optional gene-specific offsets).
+            Sample-wise scaling factors with shape ``(n_samples,)``, or
+            sample-by-gene normalization factors with shape
+            ``(n_samples, n_genes)`` (obtained from median-of-ratios and optional
+            gene-specific offsets).
 
         design_matrix : ndarray
             Design matrix.
@@ -46,7 +52,7 @@ class Inference(ABC):
     @abstractmethod
     def irls(
         self,
-        counts: np.ndarray,
+        counts: CountMatrix,
         size_factors: np.ndarray,
         design_matrix: np.ndarray,
         disp: np.ndarray,
@@ -63,12 +69,14 @@ class Inference(ABC):
 
         Parameters
         ----------
-        counts : ndarray
-            Raw counts.
+        counts : ndarray or scipy.sparse.spmatrix or scipy.sparse.sparray
+            Raw count matrix.
 
         size_factors : ndarray
-            Sample-wise scaling factors, or sample-by-gene normalization factors
-            (obtained from median-of-ratios and optional gene-specific offsets).
+            Sample-wise scaling factors with shape ``(n_samples,)``, or
+            sample-by-gene normalization factors with shape
+            ``(n_samples, n_genes)`` (obtained from median-of-ratios and optional
+            gene-specific offsets).
 
         design_matrix : ndarray
             Design matrix.
@@ -122,7 +130,7 @@ class Inference(ABC):
     @abstractmethod
     def alpha_mle(
         self,
-        counts: np.ndarray,
+        counts: CountMatrix,
         design_matrix: np.ndarray,
         mu: np.ndarray,
         alpha_hat: np.ndarray,
@@ -137,8 +145,8 @@ class Inference(ABC):
 
         Parameters
         ----------
-        counts : ndarray
-            Raw counts.
+        counts : ndarray or scipy.sparse.spmatrix or scipy.sparse.sparray
+            Raw count matrix.
 
         design_matrix : ndarray
             Design matrix.
@@ -274,7 +282,9 @@ class Inference(ABC):
             Array of deseq2-normalized read counts. Rows: samples, columns: genes.
 
         size_factors : ndarray
-            DESeq2 normalization factors.
+            Sample-wise scaling factors with shape ``(n_samples,)``, or
+            sample-by-gene normalization factors with shape
+            ``(n_samples, n_genes)``.
 
         Returns
         -------
@@ -312,7 +322,7 @@ class Inference(ABC):
     def lfc_shrink_nbinom_glm(
         self,
         design_matrix: np.ndarray,
-        counts: np.ndarray,
+        counts: CountMatrix,
         size: np.ndarray,
         offset: np.ndarray,
         prior_no_shrink_scale: float,
@@ -329,14 +339,16 @@ class Inference(ABC):
         design_matrix : ndarray
             Design matrix.
 
-        counts : ndarray
-            Raw counts.
+        counts : ndarray or scipy.sparse.spmatrix or scipy.sparse.sparray
+            Raw count matrix.
 
         size : ndarray
             Size parameter of NB family (inverse of dispersion).
 
         offset : ndarray
-            Natural logarithm of size factor.
+            Natural logarithm of sample-wise size factors with shape
+            ``(n_samples,)``, or sample-by-gene normalization factors with shape
+            ``(n_samples, n_genes)``.
 
         prior_no_shrink_scale : float
             Prior variance for the intercept.

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -2,6 +2,7 @@ import multiprocessing
 from math import ceil
 from math import floor
 from pathlib import Path
+from typing import Any
 from typing import Literal
 from typing import cast
 
@@ -10,6 +11,7 @@ import pandas as pd
 from matplotlib import pyplot as plt
 from scipy.linalg import solve  # type: ignore
 from scipy.optimize import minimize  # type: ignore
+from scipy.sparse import issparse  # type: ignore
 from scipy.special import gammaln  # type: ignore
 from scipy.special import polygamma  # type: ignore
 from scipy.stats import norm  # type: ignore
@@ -114,7 +116,7 @@ def test_valid_counts(counts: pd.DataFrame | np.ndarray) -> None:
 
     Parameters
     ----------
-    counts : pandas.DataFrame or ndarray
+    counts : pandas.DataFrame, ndarray or scipy sparse matrix
         Raw counts. One column per gene, rows are indexed by sample barcodes.
     """
     if isinstance(counts, pd.DataFrame):
@@ -122,6 +124,17 @@ def test_valid_counts(counts: pd.DataFrame | np.ndarray) -> None:
             raise ValueError("NaNs are not allowed in the count matrix.")
         if not np.issubdtype(counts.to_numpy().dtype, np.number):
             raise ValueError("The count matrix should only contain numbers.")
+    elif issparse(counts):
+        values = np.asarray(cast(Any, counts).data)
+        if not np.issubdtype(values.dtype, np.number):
+            raise ValueError("The count matrix should only contain numbers.")
+        if np.isnan(values).any():
+            raise ValueError("NaNs are not allowed in the count matrix.")
+        if (values % 1 != 0).any():
+            raise ValueError("The count matrix should only contain integers.")
+        if (values < 0).any():
+            raise ValueError("The count matrix should only contain non-negative values.")
+        return
     else:
         if np.isnan(counts).any().any():
             raise ValueError("NaNs are not allowed in the count matrix.")
@@ -876,8 +889,13 @@ def fit_moments_dispersions(
     """
     # Exclude genes with all zeroes
     normed_counts = normed_counts[:, ~(normed_counts == 0).all(axis=0)]
-    # mean inverse size factor
-    s_mean_inv = (1 / size_factors).mean(axis=0)
+    # Mean inverse size factor. For gene-specific normalization factors, DESeq2
+    # first averages factors across genes within each sample, then averages the
+    # inverse sample means into one scalar shared by all genes.
+    if size_factors.ndim == 1:
+        s_mean_inv = (1 / size_factors).mean()
+    else:
+        s_mean_inv = (1 / size_factors.mean(axis=1)).mean()
     mu = normed_counts.mean(0)
     sigma = normed_counts.var(0, ddof=1)
     # ddof=1 is to use an unbiased estimator, as in R

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -11,7 +11,8 @@ import pandas as pd
 from matplotlib import pyplot as plt
 from scipy.linalg import solve  # type: ignore
 from scipy.optimize import minimize  # type: ignore
-from scipy.sparse import issparse  # type: ignore
+from scipy.sparse import sparray  # type: ignore
+from scipy.sparse import spmatrix  # type: ignore
 from scipy.special import gammaln  # type: ignore
 from scipy.special import polygamma  # type: ignore
 from scipy.stats import norm  # type: ignore
@@ -109,14 +110,16 @@ def load_example_data(
     return df
 
 
-def test_valid_counts(counts: pd.DataFrame | np.ndarray) -> None:
+def test_valid_counts(
+    counts: pd.DataFrame | np.ndarray | spmatrix | sparray,
+) -> None:
     """Test that the count matrix contains valid inputs.
 
     More precisely, test that inputs are non-negative integers.
 
     Parameters
     ----------
-    counts : pandas.DataFrame, ndarray or scipy.sparse.spmatrix
+    counts : pandas.DataFrame, ndarray, scipy.sparse.spmatrix or scipy.sparse.sparray
         Raw counts. One column per gene, rows are indexed by sample barcodes.
     """
     if isinstance(counts, pd.DataFrame):
@@ -124,7 +127,7 @@ def test_valid_counts(counts: pd.DataFrame | np.ndarray) -> None:
             raise ValueError("NaNs are not allowed in the count matrix.")
         if not np.issubdtype(counts.to_numpy().dtype, np.number):
             raise ValueError("The count matrix should only contain numbers.")
-    elif issparse(counts):
+    elif isinstance(counts, (spmatrix, sparray)):
         values = np.asarray(cast(Any, counts).data)
         if not np.issubdtype(values.dtype, np.number):
             raise ValueError("The count matrix should only contain numbers.")
@@ -888,13 +891,15 @@ def fit_moments_dispersions(
         Estimated dispersion parameter for each gene.
     """
     # Exclude genes with all zeroes
-    normed_counts = normed_counts[:, ~(normed_counts == 0).all(axis=0)]
+    nonzero_genes = ~(normed_counts == 0).all(axis=0)
+    normed_counts = normed_counts[:, nonzero_genes]
     # Mean inverse size factor. For gene-specific normalization factors, DESeq2
     # first averages factors across genes within each sample, then averages the
     # inverse sample means into one scalar shared by all genes.
     if size_factors.ndim == 1:
         s_mean_inv = (1 / size_factors).mean()
     else:
+        size_factors = size_factors[:, nonzero_genes]
         s_mean_inv = (1 / size_factors.mean(axis=1)).mean()
     mu = normed_counts.mean(0)
     sigma = normed_counts.var(0, ddof=1)

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -128,7 +128,11 @@ def test_valid_counts(
         if not np.issubdtype(counts.to_numpy().dtype, np.number):
             raise ValueError("The count matrix should only contain numbers.")
     elif isinstance(counts, (spmatrix, sparray)):
-        values = np.asarray(cast(Any, counts).data)
+        sparse_counts = cast(Any, counts)
+        if sparse_counts.format not in {"coo", "csc", "csr"}:
+            values = np.asarray(sparse_counts.tocoo(copy=False).data)
+        else:
+            values = np.asarray(sparse_counts.data)
         if not np.issubdtype(values.dtype, np.number):
             raise ValueError("The count matrix should only contain numbers.")
         if np.isnan(values).any():

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -137,11 +137,7 @@ def test_valid_counts(
             raise ValueError("The count matrix should only contain numbers.")
         if np.isnan(values).any():
             raise ValueError("NaNs are not allowed in the count matrix.")
-        if (values % 1 != 0).any():
-            raise ValueError("The count matrix should only contain integers.")
-        if (values < 0).any():
-            raise ValueError("The count matrix should only contain non-negative values.")
-        return
+        counts = values
     else:
         if np.isnan(counts).any().any():
             raise ValueError("NaNs are not allowed in the count matrix.")
@@ -900,11 +896,9 @@ def fit_moments_dispersions(
     # Mean inverse size factor. For gene-specific normalization factors, DESeq2
     # first averages factors across genes within each sample, then averages the
     # inverse sample means into one scalar shared by all genes.
-    if size_factors.ndim == 1:
-        s_mean_inv = (1 / size_factors).mean()
-    else:
-        size_factors = size_factors[:, nonzero_genes]
-        s_mean_inv = (1 / size_factors.mean(axis=1)).mean()
+    if size_factors.ndim != 1:
+        size_factors = size_factors[:, nonzero_genes].mean(axis=1)
+    s_mean_inv = (1 / size_factors).mean()
     mu = normed_counts.mean(0)
     sigma = normed_counts.var(0, ddof=1)
     # ddof=1 is to use an unbiased estimator, as in R

--- a/pydeseq2/utils.py
+++ b/pydeseq2/utils.py
@@ -116,7 +116,7 @@ def test_valid_counts(counts: pd.DataFrame | np.ndarray) -> None:
 
     Parameters
     ----------
-    counts : pandas.DataFrame, ndarray or scipy sparse matrix
+    counts : pandas.DataFrame, ndarray or scipy.sparse.spmatrix
         Raw counts. One column per gene, rows are indexed by sample barcodes.
     """
     if isinstance(counts, pd.DataFrame):

--- a/tests/test_transcript_length_normalization.py
+++ b/tests/test_transcript_length_normalization.py
@@ -4,12 +4,23 @@ import anndata as ad
 import numpy as np
 import pandas as pd
 import pytest
+from scipy.sparse import bsr_array
+from scipy.sparse import bsr_matrix
+from scipy.sparse import coo_array
+from scipy.sparse import coo_matrix
 from scipy.sparse import csc_array
 from scipy.sparse import csc_matrix
 from scipy.sparse import csr_array
 from scipy.sparse import csr_matrix
+from scipy.sparse import dia_array
+from scipy.sparse import dia_matrix
+from scipy.sparse import dok_array
+from scipy.sparse import dok_matrix
+from scipy.sparse import lil_array
+from scipy.sparse import lil_matrix
 
 from pydeseq2.dds import DeseqDataSet
+from pydeseq2.default_inference import DefaultInference
 from pydeseq2.ds import DeseqStats
 from pydeseq2.utils import fit_moments_dispersions
 from pydeseq2.utils import load_example_data
@@ -67,6 +78,21 @@ def varying_transcript_lengths(counts):
     lengths = (800.0 + 100.0 * np.arange(counts.shape[1]))[None, :]
     lengths = lengths * (1.0 + 0.2 * np.outer(sample_effect, gene_effect))
     return pd.DataFrame(lengths, index=counts.index, columns=counts.columns)
+
+
+def anndata_with_sparse_counts(sparse_counts, *, obs=None, var=None):
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="AnnData previously had undefined behavior around matrices",
+                category=FutureWarning,
+            )
+            return ad.AnnData(X=sparse_counts, obs=obs, var=var)
+    except ValueError as error:
+        if not str(error).startswith("Only CSR and CSC"):
+            raise
+        pytest.skip(f"{type(sparse_counts).__name__} is not supported by AnnData")
 
 
 def test_transcript_length_normalization_matches_deseq2_formula():
@@ -266,6 +292,17 @@ def test_transcript_length_factors_are_used_throughout_pipeline(
     )
     assert isinstance(dds.X, sparse_constructor)
 
+    restored_dds = DeseqDataSet(
+        adata=dds,
+        design="~0 + condition",
+        fit_type="mean",
+        refit_cooks=False,
+        n_cpus=1,
+        quiet=True,
+    )
+    assert restored_dds.vst_fit_type == dds.vst_fit_type
+    np.testing.assert_allclose(restored_dds.vst_transform(), dds.vst_transform())
+
 
 @pytest.mark.parametrize(
     "sparse_constructor", [csr_matrix, csc_matrix, csr_array, csc_array]
@@ -311,6 +348,110 @@ def test_sparse_anndata_ratio_pipeline_matches_dense(sparse_constructor):
     )
     np.testing.assert_allclose(dds.varm["LFC"], reference_dds.varm["LFC"])
     assert isinstance(dds.X, sparse_constructor)
+
+
+@pytest.mark.parametrize(
+    "sparse_constructor",
+    [
+        bsr_matrix,
+        coo_matrix,
+        dia_matrix,
+        dok_matrix,
+        lil_matrix,
+        bsr_array,
+        coo_array,
+        dia_array,
+        dok_array,
+        lil_array,
+    ],
+)
+def test_general_sparse_anndata_pipeline_matches_dense(sparse_constructor):
+    counts, metadata, _ = small_tximport_data()
+    counts = counts.round().astype(int)
+    adata = anndata_with_sparse_counts(
+        sparse_constructor(counts.to_numpy()),
+        obs=metadata.copy(),
+        var=pd.DataFrame(index=counts.columns),
+    )
+
+    dds = DeseqDataSet(adata=adata, design="~condition", quiet=True)
+    reference_dds = DeseqDataSet(
+        counts=counts, metadata=metadata, design="~condition", quiet=True
+    )
+    dds.fit_genewise_dispersions()
+    reference_dds.fit_genewise_dispersions()
+
+    assert dds.X.format == "csr"
+    np.testing.assert_allclose(
+        dds.obs["size_factors"], reference_dds.obs["size_factors"]
+    )
+    np.testing.assert_allclose(
+        dds.layers["normed_counts"], reference_dds.layers["normed_counts"]
+    )
+    np.testing.assert_allclose(
+        dds.var["genewise_dispersions"], reference_dds.var["genewise_dispersions"]
+    )
+
+
+@pytest.mark.parametrize(
+    "sparse_constructor",
+    [coo_matrix, csr_matrix, csc_matrix, coo_array, csr_array, csc_array],
+)
+def test_sparse_anndata_sums_duplicates_before_validation(sparse_constructor):
+    data = np.array([0.5, 0.5, 2.0])
+    if sparse_constructor in (coo_matrix, coo_array):
+        sparse_counts = sparse_constructor(
+            (data, (np.array([0, 0, 1]), np.array([0, 0, 1]))),
+            shape=(2, 2),
+        )
+    else:
+        sparse_counts = sparse_constructor(
+            (data, np.array([0, 0, 1]), np.array([0, 2, 3])),
+            shape=(2, 2),
+        )
+
+    adata = anndata_with_sparse_counts(sparse_counts)
+    source_data = adata.X.data.copy()
+
+    dds = DeseqDataSet(adata=adata, design="~1", quiet=True)
+
+    np.testing.assert_array_equal(dds.X.toarray(), [[1, 0], [0, 2]])
+    assert dds.X.nnz == 2
+    assert adata.X.nnz == 3
+    np.testing.assert_array_equal(adata.X.data, source_data)
+
+
+@pytest.mark.parametrize("sparse_constructor", [dok_matrix, dok_array])
+def test_general_sparse_transcript_length_counts(sparse_constructor):
+    counts, metadata, transcript_lengths = small_tximport_data()
+    adata = anndata_with_sparse_counts(
+        sparse_constructor(counts.to_numpy()),
+        obs=metadata.copy(),
+        var=pd.DataFrame(index=counts.columns),
+    )
+
+    dds = DeseqDataSet(
+        adata=adata,
+        transcript_lengths=transcript_lengths,
+        design="~condition",
+        quiet=True,
+    )
+    reference_dds = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        transcript_lengths=transcript_lengths,
+        design="~condition",
+        quiet=True,
+    )
+    dds.fit_size_factors()
+    reference_dds.fit_size_factors()
+
+    assert dds.X.format == "csr"
+    np.testing.assert_array_equal(dds.X.toarray(), np.rint(counts.to_numpy()))
+    np.testing.assert_allclose(
+        dds.layers["normalization_factors"],
+        reference_dds.layers["normalization_factors"],
+    )
 
 
 @pytest.mark.parametrize(
@@ -413,6 +554,21 @@ def test_sparse_ratio_falls_back_to_iterative(monkeypatch, sparse_constructor):
         dds.fit_size_factors("ratio")
 
     assert iterative_called
+
+
+@pytest.mark.parametrize("sparse_constructor", [csr_array, csc_array])
+def test_sparse_array_cooks_outlier(sparse_constructor):
+    counts, metadata, _ = small_tximport_data()
+    counts = counts.round().astype(int)
+    adata = ad.AnnData(
+        X=sparse_constructor(counts.to_numpy()),
+        obs=metadata.copy(),
+        var=pd.DataFrame(index=counts.columns),
+    )
+    dds = DeseqDataSet(adata=adata, design="~condition", refit_cooks=False, quiet=True)
+    dds.layers["cooks"] = np.zeros(dds.shape)
+    dds.layers["cooks"][-1, 0] = np.inf
+    np.testing.assert_array_equal(dds.cooks_outlier(), [True, False, False])
 
 
 def test_moments_dispersions_match_deseq2_with_matrix_factors():
@@ -592,6 +748,93 @@ def test_explicit_transcript_lengths_clear_inherited_normalization_state():
     )
 
 
+@pytest.mark.parametrize("length_source", ["canonical", "pytximport"])
+def test_implicit_transcript_lengths_clear_scalar_normalization_state(
+    length_source,
+):
+    counts, metadata, transcript_lengths = small_tximport_data()
+    counts = counts.round().astype(int)
+    source = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        design="~condition",
+        quiet=True,
+    )
+    source.fit_size_factors()
+    source_size_factors = source.obs["size_factors"].copy()
+    source_normed_counts = source.layers["normed_counts"].copy()
+
+    if length_source == "canonical":
+        source.layers["avg_tx_length"] = transcript_lengths.to_numpy()
+    else:
+        source.obsm["length"] = transcript_lengths.to_numpy()
+        source.uns["counts_from_abundance"] = None
+
+    dds = DeseqDataSet(adata=source, design="~condition", quiet=True)
+    assert "size_factors" not in dds.obs
+    assert set(dds.layers).isdisjoint({"normalization_factors", "normed_counts"})
+
+    reference_dds = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        transcript_lengths=transcript_lengths,
+        design="~condition",
+        quiet=True,
+    )
+    dds.fit_genewise_dispersions()
+    reference_dds.fit_genewise_dispersions()
+
+    np.testing.assert_allclose(
+        dds.layers["normalization_factors"],
+        reference_dds.layers["normalization_factors"],
+    )
+    np.testing.assert_allclose(
+        dds.layers["normed_counts"], reference_dds.layers["normed_counts"]
+    )
+    np.testing.assert_allclose(
+        dds.var["genewise_dispersions"], reference_dds.var["genewise_dispersions"]
+    )
+    pd.testing.assert_series_equal(source.obs["size_factors"], source_size_factors)
+    np.testing.assert_allclose(source.layers["normed_counts"], source_normed_counts)
+
+
+def test_inherited_normalization_uses_effective_fit_settings():
+    counts, metadata, transcript_lengths = small_tximport_data()
+    source = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        transcript_lengths=transcript_lengths,
+        design="~condition",
+        quiet=True,
+    )
+    source.fit_size_factors(
+        fit_type="poscounts",
+        control_genes=["gene1", "gene2"],
+    )
+    source_factors = source.layers["normalization_factors"].copy()
+
+    mismatched_dds = DeseqDataSet(
+        adata=source,
+        design="~condition",
+        quiet=True,
+    )
+    assert "size_factors" not in mismatched_dds.obs
+    assert "normalization_factors" not in mismatched_dds.layers
+
+    matching_dds = DeseqDataSet(
+        adata=source,
+        design="~condition",
+        size_factors_fit_type="poscounts",
+        control_genes=["gene1", "gene2"],
+        quiet=True,
+    )
+    np.testing.assert_allclose(
+        matching_dds.layers["normalization_factors"],
+        source_factors,
+    )
+    np.testing.assert_allclose(source.layers["normalization_factors"], source_factors)
+
+
 def test_explicit_transcript_lengths_clear_inherited_fitted_state():
     counts = load_example_data("raw_counts", "synthetic", debug=False)
     metadata = load_example_data("metadata", "synthetic", debug=False)
@@ -607,6 +850,46 @@ def test_explicit_transcript_lengths_clear_inherited_fitted_state():
         quiet=True,
     )
     fitted_dds.deseq2()
+
+    mismatched_design_dds = DeseqDataSet(
+        adata=fitted_dds,
+        design="~condition",
+        fit_type="mean",
+        refit_cooks=False,
+        n_cpus=1,
+        quiet=True,
+    )
+    mismatched_refit_dds = DeseqDataSet(
+        adata=fitted_dds,
+        design="~0 + condition",
+        fit_type="mean",
+        refit_cooks=True,
+        n_cpus=1,
+        quiet=True,
+    )
+    for mismatched_dds in (mismatched_design_dds, mismatched_refit_dds):
+        assert "size_factors" not in mismatched_dds.obs
+        assert "normalization_factors" not in mismatched_dds.layers
+        assert "LFC" not in mismatched_dds.varm
+        assert not hasattr(mismatched_dds, "non_zero_idx")
+
+    restored_dds = DeseqDataSet(
+        adata=fitted_dds,
+        design="~0 + condition",
+        fit_type="mean",
+        refit_cooks=False,
+        n_cpus=1,
+        quiet=True,
+    )
+    np.testing.assert_array_equal(restored_dds.non_zero_idx, fitted_dds.non_zero_idx)
+    assert restored_dds.non_zero_genes.equals(fitted_dds.non_zero_genes)
+    restored_stats = DeseqStats(
+        restored_dds, contrast=["condition", "B", "A"], quiet=True, n_cpus=1
+    )
+    restored_stats.summary()
+    coefficient = restored_stats.LFC.columns[-1]
+    restored_stats.lfc_shrink(coeff=coefficient, adapt=False)
+    assert restored_stats.shrunk_LFCs
 
     replacement_lengths = transcript_lengths.copy()
     replacement_lengths.iloc[:, 0] *= np.linspace(1.0, 2.0, len(replacement_lengths))
@@ -693,6 +976,60 @@ def test_explicit_transcript_lengths_clear_inherited_fitted_state():
     np.testing.assert_allclose(dds.varm["LFC"], reference_dds.varm["LFC"])
 
 
+def test_inherited_fit_requires_complete_configuration_provenance():
+    class CustomInference(DefaultInference):
+        pass
+
+    counts = load_example_data("raw_counts", "synthetic", debug=False)
+    metadata = load_example_data("metadata", "synthetic", debug=False)
+    transcript_lengths = varying_transcript_lengths(counts)
+    custom_inference = CustomInference(n_cpus=1)
+    fitted_dds = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        transcript_lengths=transcript_lengths,
+        design="~0 + condition",
+        fit_type="mean",
+        refit_cooks=False,
+        inference=custom_inference,
+        n_cpus=1,
+        quiet=True,
+    )
+    fitted_dds.deseq2()
+
+    picklable_adata = fitted_dds.to_picklable_anndata()
+    picklable_adata.inference = custom_inference
+    missing_provenance_dds = DeseqDataSet(
+        adata=picklable_adata,
+        design="~0 + condition",
+        fit_type="parametric",
+        refit_cooks=True,
+        inference=custom_inference,
+        n_cpus=1,
+        quiet=True,
+    )
+    omitted_custom_inference_dds = DeseqDataSet(
+        adata=fitted_dds,
+        design="~0 + condition",
+        fit_type="mean",
+        refit_cooks=False,
+        n_cpus=1,
+        quiet=True,
+    )
+
+    for incompatible_dds in (
+        missing_provenance_dds,
+        omitted_custom_inference_dds,
+    ):
+        assert "size_factors" not in incompatible_dds.obs
+        assert "normalization_factors" not in incompatible_dds.layers
+        assert "LFC" not in incompatible_dds.varm
+        assert not hasattr(incompatible_dds, "non_zero_idx")
+
+    assert "LFC" in fitted_dds.varm
+    assert hasattr(fitted_dds, "non_zero_idx")
+
+
 @pytest.mark.parametrize("sparse_constructor", [csr_matrix, csc_matrix])
 def test_cooks_outlier_refit_preserves_matrix_factors(sparse_constructor):
     counts = load_example_data("raw_counts", "synthetic", debug=False)
@@ -758,6 +1095,26 @@ def test_cooks_outlier_refit_preserves_matrix_factors(sparse_constructor):
         reference_dds.varm["LFC"].loc[reference_dds.var_names[refitted]],
     )
     assert isinstance(dds.X, sparse_constructor)
+
+    source_lfc = dds.varm["LFC"].copy()
+    restored_dds = DeseqDataSet(
+        adata=dds,
+        design="~0 + condition",
+        fit_type="mean",
+        refit_cooks=True,
+        min_replicates=3,
+        n_cpus=1,
+        quiet=True,
+    )
+    assert restored_dds.new_all_zeroes_genes.equals(dds.new_all_zeroes_genes)
+    assert restored_dds.counts_to_refit is not dds.counts_to_refit
+    np.testing.assert_array_equal(restored_dds.counts_to_refit.X, dds.counts_to_refit.X)
+    np.testing.assert_allclose(
+        restored_dds.counts_to_refit.layers["normalization_factors"],
+        dds.counts_to_refit.layers["normalization_factors"],
+    )
+    restored_dds.varm["LFC"].iloc[0, 0] += 1
+    pd.testing.assert_frame_equal(dds.varm["LFC"], source_lfc)
 
 
 @pytest.mark.parametrize("sparse_counts", [False, True])

--- a/tests/test_transcript_length_normalization.py
+++ b/tests/test_transcript_length_normalization.py
@@ -95,6 +95,59 @@ def anndata_with_sparse_counts(sparse_counts, *, obs=None, var=None):
         pytest.skip(f"{type(sparse_counts).__name__} is not supported by AnnData")
 
 
+def assert_fit_state_cleared(dds):
+    assert set(dds.obs).isdisjoint({"size_factors", "replaceable"})
+    assert set(dds.var).isdisjoint(
+        {
+            "_normed_means",
+            "non_zero",
+            "_MoM_dispersions",
+            "genewise_dispersions",
+            "vst_genewise_dispersions",
+            "_genewise_converged",
+            "fitted_dispersions",
+            "MAP_dispersions",
+            "_MAP_converged",
+            "dispersions",
+            "_outlier_genes",
+            "_LFC_converged",
+            "_pvalue_cooks_outlier",
+            "replaced",
+            "refitted",
+        }
+    )
+    assert set(dds.obsm).isdisjoint({"_mu_LFC", "_hat_diagonals"})
+    assert "LFC" not in dds.varm
+    assert set(dds.layers).isdisjoint(
+        {
+            "normalization_factors",
+            "normed_counts",
+            "_mu_hat",
+            "_vst_mu_hat",
+            "cooks",
+            "replace_cooks",
+            "vst_counts",
+        }
+    )
+    assert set(dds.uns).isdisjoint(
+        {
+            "trend_coeffs",
+            "vst_trend_coeffs",
+            "mean_disp",
+            "disp_function_type",
+            "_squared_logres",
+            "prior_disp_var",
+        }
+    )
+    for attr in (
+        "non_zero_idx",
+        "non_zero_genes",
+        "counts_to_refit",
+        "new_all_zeroes_genes",
+    ):
+        assert not hasattr(dds, attr)
+
+
 def test_transcript_length_normalization_matches_deseq2_formula():
     counts, metadata, transcript_lengths = small_tximport_data()
     dds = DeseqDataSet(
@@ -161,17 +214,32 @@ def test_poscounts_transcript_length_normalization_matches_deseq2_formula():
     np.testing.assert_allclose(dds.layers["normalization_factors"], expected_factors)
 
 
-@pytest.mark.parametrize("bad_value", [0.0, -1.0, np.nan, np.inf])
-def test_transcript_lengths_must_be_positive_and_finite(bad_value):
-    counts, metadata, transcript_lengths = small_tximport_data()
-    transcript_lengths.iloc[0, 0] = bad_value
+@pytest.mark.parametrize(
+    ("length_source", "bad_value"),
+    [
+        ("explicit", 0.0),
+        ("explicit", np.nan),
+        ("pytximport", np.inf),
+    ],
+)
+def test_transcript_lengths_must_be_positive_and_finite(length_source, bad_value):
+    if length_source == "explicit":
+        counts, metadata, transcript_lengths = small_tximport_data()
+        transcript_lengths.iloc[0, 0] = bad_value
+        kwargs = {
+            "counts": counts,
+            "metadata": metadata,
+            "transcript_lengths": transcript_lengths,
+        }
+    else:
+        adata, _, _, _ = small_pytximport_adata()
+        lengths = np.asarray(adata.obsm["length"]).copy()
+        lengths[0, 0] = bad_value
+        adata.obsm["length"] = lengths
+        kwargs = {"adata": adata}
 
     with pytest.raises(ValueError, match="transcript_lengths"):
-        DeseqDataSet(
-            counts=counts,
-            metadata=metadata,
-            transcript_lengths=transcript_lengths,
-        )
+        DeseqDataSet(**kwargs)
 
 
 def test_transcript_length_labels_must_match_counts():
@@ -211,15 +279,12 @@ def test_external_vst_transform_requires_matching_transcript_lengths():
         dds.vst_transform(dds.X)
 
 
-@pytest.mark.parametrize("sparse_constructor", [csr_matrix, csc_matrix])
-def test_transcript_length_factors_are_used_throughout_pipeline(
-    monkeypatch, sparse_constructor
-):
+def test_transcript_length_factors_are_used_throughout_pipeline(monkeypatch):
     counts = load_example_data("raw_counts", "synthetic", debug=False)
     metadata = load_example_data("metadata", "synthetic", debug=False)
     transcript_lengths = varying_transcript_lengths(counts)
     adata = ad.AnnData(
-        X=sparse_constructor(counts.to_numpy()),
+        X=csc_matrix(counts.to_numpy()),
         obs=metadata,
         var=pd.DataFrame(index=counts.columns),
     )
@@ -247,6 +312,10 @@ def test_transcript_length_factors_are_used_throughout_pipeline(
     dds.deseq2()
     reference_dds.deseq2()
 
+    np.testing.assert_allclose(
+        dds.layers["normalization_factors"],
+        reference_dds.layers["normalization_factors"],
+    )
     dispersion_columns = ["_MoM_dispersions", "genewise_dispersions", "dispersions"]
     np.testing.assert_allclose(
         dds.var[dispersion_columns].to_numpy(),
@@ -290,7 +359,7 @@ def test_transcript_length_factors_are_used_throughout_pipeline(
     np.testing.assert_allclose(
         dds.layers["vst_counts"], reference_dds.layers["vst_counts"]
     )
-    assert isinstance(dds.X, sparse_constructor)
+    assert isinstance(dds.X, csc_matrix)
 
     restored_dds = DeseqDataSet(
         adata=dds,
@@ -304,9 +373,7 @@ def test_transcript_length_factors_are_used_throughout_pipeline(
     np.testing.assert_allclose(restored_dds.vst_transform(), dds.vst_transform())
 
 
-@pytest.mark.parametrize(
-    "sparse_constructor", [csr_matrix, csc_matrix, csr_array, csc_array]
-)
+@pytest.mark.parametrize("sparse_constructor", [csr_matrix, csr_array])
 def test_sparse_anndata_ratio_pipeline_matches_dense(sparse_constructor):
     counts = load_example_data("raw_counts", "synthetic", debug=False)
     metadata = load_example_data("metadata", "synthetic", debug=False)
@@ -375,31 +442,17 @@ def test_general_sparse_anndata_pipeline_matches_dense(sparse_constructor):
     )
 
     dds = DeseqDataSet(adata=adata, design="~condition", quiet=True)
-    reference_dds = DeseqDataSet(
-        counts=counts, metadata=metadata, design="~condition", quiet=True
-    )
-    dds.fit_genewise_dispersions()
-    reference_dds.fit_genewise_dispersions()
-
     assert dds.X.format == "csr"
-    np.testing.assert_allclose(
-        dds.obs["size_factors"], reference_dds.obs["size_factors"]
-    )
-    np.testing.assert_allclose(
-        dds.layers["normed_counts"], reference_dds.layers["normed_counts"]
-    )
-    np.testing.assert_allclose(
-        dds.var["genewise_dispersions"], reference_dds.var["genewise_dispersions"]
-    )
+    np.testing.assert_array_equal(dds.X.toarray(), counts.to_numpy())
 
 
 @pytest.mark.parametrize(
     "sparse_constructor",
-    [coo_matrix, csr_matrix, csc_matrix, coo_array, csr_array, csc_array],
+    [coo_matrix, csr_array, csc_matrix],
 )
 def test_sparse_anndata_sums_duplicates_before_validation(sparse_constructor):
     data = np.array([0.5, 0.5, 2.0])
-    if sparse_constructor in (coo_matrix, coo_array):
+    if sparse_constructor is coo_matrix:
         sparse_counts = sparse_constructor(
             (data, (np.array([0, 0, 1]), np.array([0, 0, 1]))),
             shape=(2, 2),
@@ -421,11 +474,10 @@ def test_sparse_anndata_sums_duplicates_before_validation(sparse_constructor):
     np.testing.assert_array_equal(adata.X.data, source_data)
 
 
-@pytest.mark.parametrize("sparse_constructor", [dok_matrix, dok_array])
-def test_general_sparse_transcript_length_counts(sparse_constructor):
+def test_general_sparse_transcript_length_counts():
     counts, metadata, transcript_lengths = small_tximport_data()
     adata = anndata_with_sparse_counts(
-        sparse_constructor(counts.to_numpy()),
+        dok_array(counts.to_numpy()),
         obs=metadata.copy(),
         var=pd.DataFrame(index=counts.columns),
     )
@@ -436,34 +488,21 @@ def test_general_sparse_transcript_length_counts(sparse_constructor):
         design="~condition",
         quiet=True,
     )
-    reference_dds = DeseqDataSet(
-        counts=counts,
-        metadata=metadata,
-        transcript_lengths=transcript_lengths,
-        design="~condition",
-        quiet=True,
-    )
     dds.fit_size_factors()
-    reference_dds.fit_size_factors()
 
     assert dds.X.format == "csr"
     np.testing.assert_array_equal(dds.X.toarray(), np.rint(counts.to_numpy()))
-    np.testing.assert_allclose(
-        dds.layers["normalization_factors"],
-        reference_dds.layers["normalization_factors"],
-    )
+    assert "normalization_factors" in dds.layers
+    assert dds.layers["normalization_factors"].shape == dds.shape
 
 
-@pytest.mark.parametrize(
-    "sparse_constructor", [csr_matrix, csc_matrix, csr_array, csc_array]
-)
-def test_sparse_anndata_poscounts_size_factors_match_dense(sparse_constructor):
+def test_sparse_anndata_poscounts_size_factors_match_dense():
     counts, metadata, _ = small_tximport_data()
     counts = counts.round().astype(int)
     for idx in range(counts.shape[1]):
         counts.iat[idx, idx] = 0
     adata = ad.AnnData(
-        X=sparse_constructor(counts.to_numpy()),
+        X=csc_array(counts.to_numpy()),
         obs=metadata.copy(),
         var=pd.DataFrame(index=counts.columns),
     )
@@ -485,17 +524,14 @@ def test_sparse_anndata_poscounts_size_factors_match_dense(sparse_constructor):
         dds.layers["normed_counts"], reference_dds.layers["normed_counts"]
     )
     assert isinstance(dds.layers["normed_counts"], np.ndarray)
-    assert isinstance(dds.X, sparse_constructor)
+    assert isinstance(dds.X, csc_array)
 
 
-@pytest.mark.parametrize(
-    "sparse_constructor", [csr_matrix, csc_matrix, csr_array, csc_array]
-)
-def test_sparse_anndata_iterative_size_factors_match_dense(sparse_constructor):
+def test_sparse_anndata_iterative_size_factors_match_dense():
     counts = load_example_data("raw_counts", "synthetic", debug=False).iloc[:20]
     metadata = load_example_data("metadata", "synthetic", debug=False).loc[counts.index]
     adata = ad.AnnData(
-        X=sparse_constructor(counts.to_numpy()),
+        X=csr_array(counts.to_numpy()),
         obs=metadata.copy(),
         var=pd.DataFrame(index=counts.columns),
     )
@@ -521,12 +557,10 @@ def test_sparse_anndata_iterative_size_factors_match_dense(sparse_constructor):
     assert dds.logmeans is None
     assert dds.filtered_genes is None
     assert isinstance(dds.layers["normed_counts"], np.ndarray)
-    assert isinstance(dds.X, sparse_constructor)
+    assert isinstance(dds.X, csr_array)
 
 
-@pytest.mark.parametrize(
-    "sparse_constructor", [csr_matrix, csc_matrix, csr_array, csc_array]
-)
+@pytest.mark.parametrize("sparse_constructor", [csr_matrix, csr_array])
 def test_sparse_ratio_falls_back_to_iterative(monkeypatch, sparse_constructor):
     counts, metadata, _ = small_tximport_data()
     counts = counts.round().astype(int)
@@ -556,12 +590,11 @@ def test_sparse_ratio_falls_back_to_iterative(monkeypatch, sparse_constructor):
     assert iterative_called
 
 
-@pytest.mark.parametrize("sparse_constructor", [csr_array, csc_array])
-def test_sparse_array_cooks_outlier(sparse_constructor):
+def test_sparse_array_cooks_outlier():
     counts, metadata, _ = small_tximport_data()
     counts = counts.round().astype(int)
     adata = ad.AnnData(
-        X=sparse_constructor(counts.to_numpy()),
+        X=csr_array(counts.to_numpy()),
         obs=metadata.copy(),
         var=pd.DataFrame(index=counts.columns),
     )
@@ -616,29 +649,6 @@ def test_moments_dispersions_align_matrix_factors_after_zero_gene_filtering():
     )
 
 
-def test_sparse_anndata_with_stored_transcript_lengths():
-    counts, metadata, transcript_lengths = small_tximport_data()
-    adata = ad.AnnData(
-        X=csr_matrix(counts.to_numpy()),
-        obs=metadata,
-        var=pd.DataFrame(index=counts.columns),
-    )
-    adata.layers["avg_tx_length"] = transcript_lengths.to_numpy()
-
-    dds = DeseqDataSet(adata=adata, quiet=True)
-    dds.fit_size_factors()
-
-    np.testing.assert_array_equal(dds.X.toarray(), np.rint(counts.to_numpy()))
-    assert "normalization_factors" in dds.layers
-    np.testing.assert_array_equal(adata.X.toarray(), counts.to_numpy())
-    np.testing.assert_allclose(
-        adata.layers["avg_tx_length"], transcript_lengths.to_numpy()
-    )
-    assert "design_matrix" not in adata.obsm
-    assert "normalization_factors" not in adata.layers
-    assert "normed_counts" not in adata.layers
-
-
 def test_sparse_estimated_counts_round_after_summing_duplicates():
     counts = csr_matrix(
         (np.array([0.4, 0.4, 0.4]), np.array([0, 0, 1]), np.array([0, 2, 3])),
@@ -691,60 +701,6 @@ def test_scalar_size_factor_refit_clears_stale_matrix_factors():
     np.testing.assert_allclose(
         dds.layers["normed_counts"],
         dds.X / dds.obs["size_factors"].to_numpy()[:, None],
-    )
-
-
-def test_explicit_transcript_lengths_clear_inherited_normalization_state():
-    counts, metadata, transcript_lengths = small_tximport_data()
-    fitted_dds = DeseqDataSet(
-        counts=counts,
-        metadata=metadata,
-        transcript_lengths=transcript_lengths,
-        quiet=True,
-    )
-    fitted_dds.fit_size_factors()
-    original_size_factors = fitted_dds.obs["size_factors"].copy()
-    original_normalization_factors = fitted_dds.layers["normalization_factors"].copy()
-    original_normed_counts = fitted_dds.layers["normed_counts"].copy()
-
-    replacement_lengths = transcript_lengths.copy()
-    replacement_lengths.iloc[:, 0] *= np.linspace(1.0, 2.0, len(replacement_lengths))
-    dds = DeseqDataSet(
-        adata=fitted_dds,
-        transcript_lengths=replacement_lengths,
-        quiet=True,
-    )
-
-    assert "size_factors" not in dds.obs
-    assert "normalization_factors" not in dds.layers
-    assert "normed_counts" not in dds.layers
-    np.testing.assert_allclose(fitted_dds.obs["size_factors"], original_size_factors)
-    np.testing.assert_allclose(
-        fitted_dds.layers["normalization_factors"],
-        original_normalization_factors,
-    )
-    np.testing.assert_allclose(
-        fitted_dds.layers["normed_counts"], original_normed_counts
-    )
-
-    reference_dds = DeseqDataSet(
-        counts=counts,
-        metadata=metadata,
-        transcript_lengths=replacement_lengths,
-        quiet=True,
-    )
-    dds.fit_genewise_dispersions()
-    reference_dds.fit_size_factors()
-
-    np.testing.assert_allclose(
-        dds.obs["size_factors"], reference_dds.obs["size_factors"]
-    )
-    np.testing.assert_allclose(
-        dds.layers["normalization_factors"],
-        reference_dds.layers["normalization_factors"],
-    )
-    np.testing.assert_allclose(
-        dds.layers["normed_counts"], reference_dds.layers["normed_counts"]
     )
 
 
@@ -850,6 +806,9 @@ def test_explicit_transcript_lengths_clear_inherited_fitted_state():
         quiet=True,
     )
     fitted_dds.deseq2()
+    original_size_factors = fitted_dds.obs["size_factors"].copy()
+    original_normalization_factors = fitted_dds.layers["normalization_factors"].copy()
+    original_normed_counts = fitted_dds.layers["normed_counts"].copy()
 
     mismatched_design_dds = DeseqDataSet(
         adata=fitted_dds,
@@ -868,10 +827,7 @@ def test_explicit_transcript_lengths_clear_inherited_fitted_state():
         quiet=True,
     )
     for mismatched_dds in (mismatched_design_dds, mismatched_refit_dds):
-        assert "size_factors" not in mismatched_dds.obs
-        assert "normalization_factors" not in mismatched_dds.layers
-        assert "LFC" not in mismatched_dds.varm
-        assert not hasattr(mismatched_dds, "non_zero_idx")
+        assert_fit_state_cleared(mismatched_dds)
 
     restored_dds = DeseqDataSet(
         adata=fitted_dds,
@@ -903,49 +859,7 @@ def test_explicit_transcript_lengths_clear_inherited_fitted_state():
         quiet=True,
     )
 
-    assert set(dds.obs.columns).isdisjoint({"size_factors", "replaceable"})
-    assert set(dds.var.columns).isdisjoint(
-        {
-            "_normed_means",
-            "non_zero",
-            "_MoM_dispersions",
-            "genewise_dispersions",
-            "vst_genewise_dispersions",
-            "_genewise_converged",
-            "fitted_dispersions",
-            "MAP_dispersions",
-            "_MAP_converged",
-            "dispersions",
-            "_outlier_genes",
-            "_LFC_converged",
-            "_pvalue_cooks_outlier",
-            "replaced",
-            "refitted",
-        }
-    )
-    assert set(dds.obsm).isdisjoint({"_mu_LFC", "_hat_diagonals"})
-    assert "LFC" not in dds.varm
-    assert set(dds.layers).isdisjoint(
-        {
-            "normalization_factors",
-            "normed_counts",
-            "_mu_hat",
-            "_vst_mu_hat",
-            "cooks",
-            "replace_cooks",
-            "vst_counts",
-        }
-    )
-    assert set(dds.uns).isdisjoint(
-        {
-            "trend_coeffs",
-            "vst_trend_coeffs",
-            "mean_disp",
-            "disp_function_type",
-            "_squared_logres",
-            "prior_disp_var",
-        }
-    )
+    assert_fit_state_cleared(dds)
     assert "size_factors" in fitted_dds.obs
     assert "genewise_dispersions" in fitted_dds.var
     assert "_mu_LFC" in fitted_dds.obsm
@@ -974,6 +888,14 @@ def test_explicit_transcript_lengths_clear_inherited_fitted_state():
     )
     np.testing.assert_allclose(dds.var["dispersions"], reference_dds.var["dispersions"])
     np.testing.assert_allclose(dds.varm["LFC"], reference_dds.varm["LFC"])
+    np.testing.assert_allclose(fitted_dds.obs["size_factors"], original_size_factors)
+    np.testing.assert_allclose(
+        fitted_dds.layers["normalization_factors"],
+        original_normalization_factors,
+    )
+    np.testing.assert_allclose(
+        fitted_dds.layers["normed_counts"], original_normed_counts
+    )
 
 
 def test_inherited_fit_requires_complete_configuration_provenance():
@@ -1021,23 +943,19 @@ def test_inherited_fit_requires_complete_configuration_provenance():
         missing_provenance_dds,
         omitted_custom_inference_dds,
     ):
-        assert "size_factors" not in incompatible_dds.obs
-        assert "normalization_factors" not in incompatible_dds.layers
-        assert "LFC" not in incompatible_dds.varm
-        assert not hasattr(incompatible_dds, "non_zero_idx")
+        assert_fit_state_cleared(incompatible_dds)
 
     assert "LFC" in fitted_dds.varm
     assert hasattr(fitted_dds, "non_zero_idx")
 
 
-@pytest.mark.parametrize("sparse_constructor", [csr_matrix, csc_matrix])
-def test_cooks_outlier_refit_preserves_matrix_factors(sparse_constructor):
+def test_cooks_outlier_refit_preserves_matrix_factors():
     counts = load_example_data("raw_counts", "synthetic", debug=False)
     metadata = load_example_data("metadata", "synthetic", debug=False)
     counts.iloc[0, 0] *= 10_000
     transcript_lengths = varying_transcript_lengths(counts)
     adata = ad.AnnData(
-        X=sparse_constructor(counts.to_numpy()),
+        X=csr_matrix(counts.to_numpy()),
         obs=metadata,
         var=pd.DataFrame(index=counts.columns),
     )
@@ -1094,7 +1012,7 @@ def test_cooks_outlier_refit_preserves_matrix_factors(sparse_constructor):
         dds.varm["LFC"].loc[dds.var_names[refitted]],
         reference_dds.varm["LFC"].loc[reference_dds.var_names[refitted]],
     )
-    assert isinstance(dds.X, sparse_constructor)
+    assert isinstance(dds.X, csr_matrix)
 
     source_lfc = dds.varm["LFC"].copy()
     restored_dds = DeseqDataSet(
@@ -1115,43 +1033,6 @@ def test_cooks_outlier_refit_preserves_matrix_factors(sparse_constructor):
     )
     restored_dds.varm["LFC"].iloc[0, 0] += 1
     pd.testing.assert_frame_equal(dds.varm["LFC"], source_lfc)
-
-
-@pytest.mark.parametrize("sparse_counts", [False, True])
-def test_pytximport_anndata_matches_explicit_transcript_lengths(sparse_counts):
-    adata, counts, metadata, transcript_lengths = small_pytximport_adata()
-    if sparse_counts:
-        adata.X = csr_matrix(adata.X)
-
-    pytximport_dds = DeseqDataSet(adata=adata, design="~condition", quiet=True)
-    explicit_dds = DeseqDataSet(
-        counts=counts,
-        metadata=metadata,
-        transcript_lengths=transcript_lengths,
-        design="~condition",
-        quiet=True,
-    )
-    pytximport_dds.fit_size_factors()
-    explicit_dds.fit_size_factors()
-
-    pytximport_counts = pytximport_dds.X.toarray() if sparse_counts else pytximport_dds.X
-    np.testing.assert_array_equal(pytximport_counts, explicit_dds.X)
-    np.testing.assert_allclose(
-        pytximport_dds.layers["avg_tx_length"],
-        explicit_dds.layers["avg_tx_length"],
-    )
-    np.testing.assert_allclose(
-        pytximport_dds.obs["size_factors"], explicit_dds.obs["size_factors"]
-    )
-    np.testing.assert_allclose(
-        pytximport_dds.layers["normalization_factors"],
-        explicit_dds.layers["normalization_factors"],
-    )
-    np.testing.assert_allclose(
-        pytximport_dds.layers["normed_counts"],
-        explicit_dds.layers["normed_counts"],
-    )
-    assert isinstance(pytximport_dds.X, csr_matrix) is sparse_counts
 
 
 def test_pytximport_backed_anndata_requires_memory(tmp_path):
@@ -1190,19 +1071,9 @@ def test_pytximport_dataframe_gene_labels_must_match():
         DeseqDataSet(adata=adata, quiet=True)
 
 
-@pytest.mark.parametrize(
-    "mode",
-    [
-        "scaled_tpm",
-        "length_scaled_tpm",
-        "dtu_scaled_tpm",
-        "scaledTPM",
-        "lengthScaledTPM",
-    ],
-)
-def test_pytximport_scaled_count_modes_are_rejected(mode):
+def test_pytximport_scaled_count_mode_is_rejected():
     adata, _, _, _ = small_pytximport_adata()
-    adata.uns["counts_from_abundance"] = mode
+    adata.uns["counts_from_abundance"] = "length_scaled_tpm"
 
     with pytest.raises(ValueError, match="unscaled estimated counts"):
         DeseqDataSet(adata=adata, quiet=True)
@@ -1229,17 +1100,6 @@ def test_scaled_pytximport_mode_rejects_higher_precedence_lengths(
         )
 
 
-@pytest.mark.parametrize("bad_value", [0.0, np.nan, np.inf])
-def test_pytximport_lengths_must_be_positive_and_finite(bad_value):
-    adata, _, _, _ = small_pytximport_adata()
-    lengths = adata.obsm["length"].copy()
-    lengths[0, 0] = bad_value
-    adata.obsm["length"] = lengths
-
-    with pytest.raises(ValueError, match="transcript_lengths"):
-        DeseqDataSet(adata=adata, quiet=True)
-
-
 def test_pytximport_lengths_reject_unsynchronized_gene_subsetting():
     adata, _, _, _ = small_pytximport_adata()
     subset = adata[:, :2].copy()
@@ -1251,7 +1111,9 @@ def test_pytximport_lengths_reject_unsynchronized_gene_subsetting():
 @pytest.mark.parametrize("use_explicit_lengths", [False, True])
 def test_transcript_length_source_precedence(use_explicit_lengths):
     adata, _, _, transcript_lengths = small_pytximport_adata()
+    adata.X = csr_matrix(adata.X)
     canonical_lengths = transcript_lengths.to_numpy() + 100.0
+    source_lengths = canonical_lengths.copy()
     explicit_lengths = transcript_lengths + 200.0
     adata.layers["avg_tx_length"] = canonical_lengths
 
@@ -1263,23 +1125,18 @@ def test_transcript_length_source_precedence(use_explicit_lengths):
 
     expected = explicit_lengths.to_numpy() if use_explicit_lengths else canonical_lengths
     np.testing.assert_allclose(dds.layers["avg_tx_length"], expected)
+    np.testing.assert_allclose(adata.layers["avg_tx_length"], source_lengths)
 
 
-def test_pytximport_length_without_mode_is_not_auto_detected():
+@pytest.mark.parametrize("missing_field", ["counts_from_abundance", "length"])
+def test_incomplete_pytximport_fields_are_not_auto_detected(missing_field):
     adata, counts, _, _ = small_pytximport_adata()
-    del adata.uns["counts_from_abundance"]
     adata.X = np.rint(counts.to_numpy())
-
-    dds = DeseqDataSet(adata=adata, quiet=True)
-
-    assert "avg_tx_length" not in dds.layers
-
-
-def test_counts_from_abundance_without_lengths_is_not_pytximport():
-    adata, counts, _, _ = small_pytximport_adata()
-    del adata.obsm["length"]
-    adata.X = np.rint(counts.to_numpy())
-    adata.uns["counts_from_abundance"] = "scaled_tpm"
+    if missing_field == "counts_from_abundance":
+        del adata.uns["counts_from_abundance"]
+    else:
+        del adata.obsm["length"]
+        adata.uns["counts_from_abundance"] = "scaled_tpm"
 
     dds = DeseqDataSet(adata=adata, quiet=True)
 
@@ -1298,6 +1155,7 @@ def test_pytximport_input_anndata_is_not_mutated():
         warnings.simplefilter("ignore", FutureWarning)
         picklable_adata = dds.to_picklable_anndata()
 
+    np.testing.assert_array_equal(dds.X, np.rint(counts.to_numpy()))
     np.testing.assert_array_equal(adata.X, counts.to_numpy())
     pd.testing.assert_frame_equal(adata.obs, original_obs)
     assert dds.var is not adata.var

--- a/tests/test_transcript_length_normalization.py
+++ b/tests/test_transcript_length_normalization.py
@@ -4,7 +4,9 @@ import anndata as ad
 import numpy as np
 import pandas as pd
 import pytest
+from scipy.sparse import csc_array
 from scipy.sparse import csc_matrix
+from scipy.sparse import csr_array
 from scipy.sparse import csr_matrix
 
 from pydeseq2.dds import DeseqDataSet
@@ -265,6 +267,154 @@ def test_transcript_length_factors_are_used_throughout_pipeline(
     assert isinstance(dds.X, sparse_constructor)
 
 
+@pytest.mark.parametrize(
+    "sparse_constructor", [csr_matrix, csc_matrix, csr_array, csc_array]
+)
+def test_sparse_anndata_ratio_pipeline_matches_dense(sparse_constructor):
+    counts = load_example_data("raw_counts", "synthetic", debug=False)
+    metadata = load_example_data("metadata", "synthetic", debug=False)
+    adata = ad.AnnData(
+        X=sparse_constructor(counts.to_numpy()),
+        obs=metadata.copy(),
+        var=pd.DataFrame(index=counts.columns),
+    )
+
+    dds = DeseqDataSet(
+        adata=adata,
+        design="~0 + condition",
+        fit_type="mean",
+        refit_cooks=False,
+        n_cpus=1,
+        quiet=True,
+    )
+    reference_dds = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        design="~0 + condition",
+        fit_type="mean",
+        refit_cooks=False,
+        n_cpus=1,
+        quiet=True,
+    )
+    dds.deseq2()
+    reference_dds.deseq2()
+
+    np.testing.assert_allclose(
+        dds.obs["size_factors"], reference_dds.obs["size_factors"]
+    )
+    np.testing.assert_allclose(
+        dds.layers["normed_counts"], reference_dds.layers["normed_counts"]
+    )
+    dispersion_columns = ["_MoM_dispersions", "genewise_dispersions", "dispersions"]
+    np.testing.assert_allclose(
+        dds.var[dispersion_columns], reference_dds.var[dispersion_columns]
+    )
+    np.testing.assert_allclose(dds.varm["LFC"], reference_dds.varm["LFC"])
+    assert isinstance(dds.X, sparse_constructor)
+
+
+@pytest.mark.parametrize(
+    "sparse_constructor", [csr_matrix, csc_matrix, csr_array, csc_array]
+)
+def test_sparse_anndata_poscounts_size_factors_match_dense(sparse_constructor):
+    counts, metadata, _ = small_tximport_data()
+    counts = counts.round().astype(int)
+    for idx in range(counts.shape[1]):
+        counts.iat[idx, idx] = 0
+    adata = ad.AnnData(
+        X=sparse_constructor(counts.to_numpy()),
+        obs=metadata.copy(),
+        var=pd.DataFrame(index=counts.columns),
+    )
+    dds = DeseqDataSet(adata=adata, design="~condition", quiet=True)
+    reference_dds = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        design="~condition",
+        quiet=True,
+    )
+
+    dds.fit_size_factors("poscounts")
+    reference_dds.fit_size_factors("poscounts")
+
+    np.testing.assert_allclose(
+        dds.obs["size_factors"], reference_dds.obs["size_factors"]
+    )
+    np.testing.assert_allclose(
+        dds.layers["normed_counts"], reference_dds.layers["normed_counts"]
+    )
+    assert isinstance(dds.layers["normed_counts"], np.ndarray)
+    assert isinstance(dds.X, sparse_constructor)
+
+
+@pytest.mark.parametrize(
+    "sparse_constructor", [csr_matrix, csc_matrix, csr_array, csc_array]
+)
+def test_sparse_anndata_iterative_size_factors_match_dense(sparse_constructor):
+    counts = load_example_data("raw_counts", "synthetic", debug=False).iloc[:20]
+    metadata = load_example_data("metadata", "synthetic", debug=False).loc[counts.index]
+    adata = ad.AnnData(
+        X=sparse_constructor(counts.to_numpy()),
+        obs=metadata.copy(),
+        var=pd.DataFrame(index=counts.columns),
+    )
+    dds = DeseqDataSet(adata=adata, design="~1", n_cpus=1, quiet=True)
+    reference_dds = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        design="~1",
+        n_cpus=1,
+        quiet=True,
+    )
+    for dataset in (dds, reference_dds):
+        dataset.logmeans = np.ones(dataset.n_vars)
+        dataset.filtered_genes = np.ones(dataset.n_vars, dtype=bool)
+        dataset._fit_iterate_size_factors(niter=1)
+
+    np.testing.assert_allclose(
+        dds.obs["size_factors"], reference_dds.obs["size_factors"]
+    )
+    np.testing.assert_allclose(
+        dds.layers["normed_counts"], reference_dds.layers["normed_counts"]
+    )
+    assert dds.logmeans is None
+    assert dds.filtered_genes is None
+    assert isinstance(dds.layers["normed_counts"], np.ndarray)
+    assert isinstance(dds.X, sparse_constructor)
+
+
+@pytest.mark.parametrize(
+    "sparse_constructor", [csr_matrix, csc_matrix, csr_array, csc_array]
+)
+def test_sparse_ratio_falls_back_to_iterative(monkeypatch, sparse_constructor):
+    counts, metadata, _ = small_tximport_data()
+    counts = counts.round().astype(int)
+    for idx in range(counts.shape[1]):
+        counts.iat[idx, idx] = 0
+    adata = ad.AnnData(
+        X=sparse_constructor(counts.to_numpy()),
+        obs=metadata.copy(),
+        var=pd.DataFrame(index=counts.columns),
+    )
+    dds = DeseqDataSet(adata=adata, design="~condition", quiet=True)
+    iterative_called = False
+
+    def fit_iterative():
+        nonlocal iterative_called
+        iterative_called = True
+        dds.obs["size_factors"] = np.ones(dds.n_obs)
+        dds.layers["normed_counts"] = dds.X.toarray()
+        dds.logmeans = None
+        dds.filtered_genes = None
+
+    monkeypatch.setattr(dds, "_fit_iterate_size_factors", fit_iterative)
+
+    with pytest.warns(UserWarning, match="Switching to iterative mode"):
+        dds.fit_size_factors("ratio")
+
+    assert iterative_called
+
+
 def test_moments_dispersions_match_deseq2_with_matrix_factors():
     counts, metadata, transcript_lengths = small_tximport_data()
     dds = DeseqDataSet(
@@ -285,6 +435,28 @@ def test_moments_dispersions_match_deseq2_with_matrix_factors():
     np.testing.assert_allclose(
         fit_moments_dispersions(normed_counts, normalization_factors),
         expected,
+    )
+
+
+def test_moments_dispersions_align_matrix_factors_after_zero_gene_filtering():
+    normed_counts = np.array(
+        [
+            [0.0, 10.0],
+            [0.0, 14.0],
+            [0.0, 18.0],
+        ]
+    )
+    normalization_factors = np.array(
+        [
+            [100.0, 1.0],
+            [100.0, 1.0],
+            [100.0, 1.0],
+        ]
+    )
+
+    np.testing.assert_allclose(
+        fit_moments_dispersions(normed_counts, normalization_factors),
+        np.array([2.0 / 196.0]),
     )
 
 
@@ -364,6 +536,161 @@ def test_scalar_size_factor_refit_clears_stale_matrix_factors():
         dds.layers["normed_counts"],
         dds.X / dds.obs["size_factors"].to_numpy()[:, None],
     )
+
+
+def test_explicit_transcript_lengths_clear_inherited_normalization_state():
+    counts, metadata, transcript_lengths = small_tximport_data()
+    fitted_dds = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        transcript_lengths=transcript_lengths,
+        quiet=True,
+    )
+    fitted_dds.fit_size_factors()
+    original_size_factors = fitted_dds.obs["size_factors"].copy()
+    original_normalization_factors = fitted_dds.layers["normalization_factors"].copy()
+    original_normed_counts = fitted_dds.layers["normed_counts"].copy()
+
+    replacement_lengths = transcript_lengths.copy()
+    replacement_lengths.iloc[:, 0] *= np.linspace(1.0, 2.0, len(replacement_lengths))
+    dds = DeseqDataSet(
+        adata=fitted_dds,
+        transcript_lengths=replacement_lengths,
+        quiet=True,
+    )
+
+    assert "size_factors" not in dds.obs
+    assert "normalization_factors" not in dds.layers
+    assert "normed_counts" not in dds.layers
+    np.testing.assert_allclose(fitted_dds.obs["size_factors"], original_size_factors)
+    np.testing.assert_allclose(
+        fitted_dds.layers["normalization_factors"],
+        original_normalization_factors,
+    )
+    np.testing.assert_allclose(
+        fitted_dds.layers["normed_counts"], original_normed_counts
+    )
+
+    reference_dds = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        transcript_lengths=replacement_lengths,
+        quiet=True,
+    )
+    dds.fit_genewise_dispersions()
+    reference_dds.fit_size_factors()
+
+    np.testing.assert_allclose(
+        dds.obs["size_factors"], reference_dds.obs["size_factors"]
+    )
+    np.testing.assert_allclose(
+        dds.layers["normalization_factors"],
+        reference_dds.layers["normalization_factors"],
+    )
+    np.testing.assert_allclose(
+        dds.layers["normed_counts"], reference_dds.layers["normed_counts"]
+    )
+
+
+def test_explicit_transcript_lengths_clear_inherited_fitted_state():
+    counts = load_example_data("raw_counts", "synthetic", debug=False)
+    metadata = load_example_data("metadata", "synthetic", debug=False)
+    transcript_lengths = varying_transcript_lengths(counts)
+    fitted_dds = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        transcript_lengths=transcript_lengths,
+        design="~0 + condition",
+        fit_type="mean",
+        refit_cooks=False,
+        n_cpus=1,
+        quiet=True,
+    )
+    fitted_dds.deseq2()
+
+    replacement_lengths = transcript_lengths.copy()
+    replacement_lengths.iloc[:, 0] *= np.linspace(1.0, 2.0, len(replacement_lengths))
+    dds = DeseqDataSet(
+        adata=fitted_dds,
+        transcript_lengths=replacement_lengths,
+        design="~0 + condition",
+        fit_type="mean",
+        refit_cooks=False,
+        n_cpus=1,
+        quiet=True,
+    )
+
+    assert set(dds.obs.columns).isdisjoint({"size_factors", "replaceable"})
+    assert set(dds.var.columns).isdisjoint(
+        {
+            "_normed_means",
+            "non_zero",
+            "_MoM_dispersions",
+            "genewise_dispersions",
+            "vst_genewise_dispersions",
+            "_genewise_converged",
+            "fitted_dispersions",
+            "MAP_dispersions",
+            "_MAP_converged",
+            "dispersions",
+            "_outlier_genes",
+            "_LFC_converged",
+            "_pvalue_cooks_outlier",
+            "replaced",
+            "refitted",
+        }
+    )
+    assert set(dds.obsm).isdisjoint({"_mu_LFC", "_hat_diagonals"})
+    assert "LFC" not in dds.varm
+    assert set(dds.layers).isdisjoint(
+        {
+            "normalization_factors",
+            "normed_counts",
+            "_mu_hat",
+            "_vst_mu_hat",
+            "cooks",
+            "replace_cooks",
+            "vst_counts",
+        }
+    )
+    assert set(dds.uns).isdisjoint(
+        {
+            "trend_coeffs",
+            "vst_trend_coeffs",
+            "mean_disp",
+            "disp_function_type",
+            "_squared_logres",
+            "prior_disp_var",
+        }
+    )
+    assert "size_factors" in fitted_dds.obs
+    assert "genewise_dispersions" in fitted_dds.var
+    assert "_mu_LFC" in fitted_dds.obsm
+    assert "LFC" in fitted_dds.varm
+    assert "cooks" in fitted_dds.layers
+    assert "mean_disp" in fitted_dds.uns
+
+    reference_dds = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        transcript_lengths=replacement_lengths,
+        design="~0 + condition",
+        fit_type="mean",
+        refit_cooks=False,
+        n_cpus=1,
+        quiet=True,
+    )
+    dds.fit_dispersion_trend()
+    reference_dds.fit_dispersion_trend()
+    dds.fit_LFC()
+    reference_dds.fit_LFC()
+
+    np.testing.assert_allclose(
+        dds.layers["normalization_factors"],
+        reference_dds.layers["normalization_factors"],
+    )
+    np.testing.assert_allclose(dds.var["dispersions"], reference_dds.var["dispersions"])
+    np.testing.assert_allclose(dds.varm["LFC"], reference_dds.varm["LFC"])
 
 
 @pytest.mark.parametrize("sparse_constructor", [csr_matrix, csc_matrix])

--- a/tests/test_transcript_length_normalization.py
+++ b/tests/test_transcript_length_normalization.py
@@ -1,0 +1,314 @@
+import warnings
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+import pytest
+from scipy.sparse import csr_matrix
+
+from pydeseq2.dds import DeseqDataSet
+from pydeseq2.ds import DeseqStats
+from pydeseq2.utils import fit_moments_dispersions
+from pydeseq2.utils import load_example_data
+
+
+def small_tximport_data():
+    samples = pd.Index([f"sample{i}" for i in range(1, 7)])
+    genes = pd.Index(["gene1", "gene2", "gene3"])
+    counts = pd.DataFrame(
+        [
+            [100.2, 201.7, 302.1],
+            [121.8, 181.2, 330.9],
+            [89.6, 240.4, 281.2],
+            [170.1, 260.8, 410.3],
+            [160.7, 290.2, 389.9],
+            [190.4, 250.6, 430.8],
+        ],
+        index=samples,
+        columns=genes,
+    )
+    metadata = pd.DataFrame(
+        {"condition": ["A", "A", "A", "B", "B", "B"]},
+        index=samples,
+    )
+    transcript_lengths = pd.DataFrame(
+        [
+            [900.0, 1400.0, 2100.0],
+            [950.0, 1350.0, 2050.0],
+            [1000.0, 1300.0, 2000.0],
+            [1250.0, 1100.0, 1850.0],
+            [1300.0, 1050.0, 1800.0],
+            [1350.0, 1000.0, 1750.0],
+        ],
+        index=samples,
+        columns=genes,
+    )
+    return counts, metadata, transcript_lengths
+
+
+def varying_transcript_lengths(counts):
+    sample_effect = np.linspace(-1.0, 1.0, counts.shape[0])
+    gene_effect = np.linspace(-1.0, 1.0, counts.shape[1])
+    lengths = (800.0 + 100.0 * np.arange(counts.shape[1]))[None, :]
+    lengths = lengths * (1.0 + 0.2 * np.outer(sample_effect, gene_effect))
+    return pd.DataFrame(lengths, index=counts.index, columns=counts.columns)
+
+
+def test_transcript_length_normalization_matches_deseq2_formula():
+    counts, metadata, transcript_lengths = small_tximport_data()
+    dds = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        transcript_lengths=transcript_lengths,
+        design="~condition",
+        quiet=True,
+    )
+    dds.fit_size_factors()
+
+    rounded_counts = np.rint(counts.to_numpy())
+    lengths = transcript_lengths.to_numpy()
+    length_factors = lengths / np.exp(np.mean(np.log(lengths), axis=0))
+    adjusted_counts = rounded_counts / length_factors
+    logmeans = np.mean(np.log(adjusted_counts), axis=0)
+    size_factors = np.exp(np.median(np.log(adjusted_counts) - logmeans, axis=1))
+    size_factors /= np.exp(np.mean(np.log(size_factors)))
+    expected_factors = length_factors * size_factors[:, None]
+    expected_factors /= np.exp(np.mean(np.log(expected_factors), axis=0))
+
+    np.testing.assert_array_equal(dds.X, rounded_counts)
+    np.testing.assert_allclose(dds.layers["avg_tx_length"], lengths)
+    np.testing.assert_allclose(dds.obs["size_factors"], size_factors)
+    np.testing.assert_allclose(dds.layers["normalization_factors"], expected_factors)
+    np.testing.assert_allclose(
+        dds.layers["normed_counts"], rounded_counts / expected_factors
+    )
+    np.testing.assert_allclose(
+        np.exp(np.mean(np.log(dds.layers["normalization_factors"]), axis=0)),
+        np.ones(dds.n_vars),
+    )
+
+
+def test_poscounts_transcript_length_normalization_matches_deseq2_formula():
+    counts, metadata, transcript_lengths = small_tximport_data()
+    for idx in range(3):
+        counts.iat[idx, idx] = 0
+    dds = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        transcript_lengths=transcript_lengths,
+        quiet=True,
+    )
+    dds.fit_size_factors("poscounts")
+
+    rounded_counts = np.rint(counts.to_numpy())
+    lengths = transcript_lengths.to_numpy()
+    length_factors = lengths / np.exp(np.mean(np.log(lengths), axis=0))
+    adjusted_counts = rounded_counts / length_factors
+    log_counts = np.zeros_like(rounded_counts)
+    np.log(rounded_counts, out=log_counts, where=rounded_counts != 0)
+    logmeans = log_counts.mean(axis=0)
+    size_factors = np.empty(dds.n_obs)
+    for sample_idx in range(dds.n_obs):
+        positive = adjusted_counts[sample_idx] > 0
+        size_factors[sample_idx] = np.exp(
+            np.median(np.log(adjusted_counts[sample_idx, positive]) - logmeans[positive])
+        )
+    size_factors /= np.exp(np.mean(np.log(size_factors)))
+    expected_factors = length_factors * size_factors[:, None]
+    expected_factors /= np.exp(np.mean(np.log(expected_factors), axis=0))
+
+    np.testing.assert_allclose(dds.layers["normalization_factors"], expected_factors)
+
+
+@pytest.mark.parametrize("bad_value", [0.0, -1.0, np.nan, np.inf])
+def test_transcript_lengths_must_be_positive_and_finite(bad_value):
+    counts, metadata, transcript_lengths = small_tximport_data()
+    transcript_lengths.iloc[0, 0] = bad_value
+
+    with pytest.raises(ValueError, match="transcript_lengths"):
+        DeseqDataSet(
+            counts=counts,
+            metadata=metadata,
+            transcript_lengths=transcript_lengths,
+        )
+
+
+def test_transcript_length_labels_must_match_counts():
+    counts, metadata, transcript_lengths = small_tximport_data()
+    transcript_lengths = transcript_lengths.rename(index={"sample1": "wrong_sample"})
+
+    with pytest.raises(ValueError, match="same sample index"):
+        DeseqDataSet(
+            counts=counts,
+            metadata=metadata,
+            transcript_lengths=transcript_lengths,
+        )
+
+
+def test_transcript_lengths_reject_iterative_size_factors():
+    counts, metadata, transcript_lengths = small_tximport_data()
+    dds = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        transcript_lengths=transcript_lengths,
+    )
+
+    with pytest.raises(ValueError, match="iterative"):
+        dds.fit_size_factors("iterative")
+
+
+def test_external_vst_transform_requires_matching_transcript_lengths():
+    counts, metadata, transcript_lengths = small_tximport_data()
+    dds = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        transcript_lengths=transcript_lengths,
+    )
+    dds.fit_size_factors()
+
+    with pytest.raises(ValueError, match="matching transcript lengths"):
+        dds.vst_transform(dds.X)
+
+
+def test_transcript_length_factors_are_used_throughout_pipeline():
+    counts = load_example_data("raw_counts", "synthetic", debug=False)
+    metadata = load_example_data("metadata", "synthetic", debug=False)
+    transcript_lengths = varying_transcript_lengths(counts)
+
+    dds = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        transcript_lengths=transcript_lengths,
+        design="~0 + condition",
+        fit_type="mean",
+        refit_cooks=False,
+        n_cpus=1,
+        quiet=True,
+    )
+    dds.deseq2()
+
+    non_zero = dds.var["non_zero"].to_numpy()
+    normalization_factors = dds.layers["normalization_factors"][:, non_zero]
+    design_matrix = dds.obsm["design_matrix"].to_numpy()
+    coefficients = dds.varm["LFC"].loc[dds.var_names[non_zero]].to_numpy()
+    expected_mu = np.maximum(
+        normalization_factors * np.exp(design_matrix @ coefficients.T),
+        dds.min_mu,
+    )
+    np.testing.assert_allclose(dds.obsm["_mu_LFC"], expected_mu)
+
+    stats = DeseqStats(dds, contrast=["condition", "B", "A"], quiet=True)
+    stats.summary()
+    assert stats.results_df["pvalue"].notna().any()
+
+    coefficient = stats.LFC.columns[-1]
+    stats.lfc_shrink(coeff=coefficient, adapt=False)
+    assert stats.shrunk_LFCs
+    assert stats.LFC[coefficient].notna().any()
+
+
+def test_moments_dispersions_match_deseq2_with_matrix_factors():
+    counts, metadata, transcript_lengths = small_tximport_data()
+    dds = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        transcript_lengths=transcript_lengths,
+        quiet=True,
+    )
+    dds.fit_size_factors()
+
+    normalization_factors = dds.layers["normalization_factors"]
+    normed_counts = dds.layers["normed_counts"]
+    mean_inverse_factor = np.mean(1 / normalization_factors.mean(axis=1))
+    means = normed_counts.mean(axis=0)
+    variances = normed_counts.var(axis=0, ddof=1)
+    expected = np.nan_to_num((variances - mean_inverse_factor * means) / means**2)
+
+    np.testing.assert_allclose(
+        fit_moments_dispersions(normed_counts, normalization_factors),
+        expected,
+    )
+
+
+def test_sparse_anndata_with_stored_transcript_lengths():
+    counts, metadata, transcript_lengths = small_tximport_data()
+    adata = ad.AnnData(
+        X=csr_matrix(counts.to_numpy()),
+        obs=metadata,
+        var=pd.DataFrame(index=counts.columns),
+    )
+    adata.layers["avg_tx_length"] = transcript_lengths.to_numpy()
+
+    dds = DeseqDataSet(adata=adata, quiet=True)
+    dds.fit_size_factors()
+
+    np.testing.assert_array_equal(dds.X.toarray(), np.rint(counts.to_numpy()))
+    assert "normalization_factors" in dds.layers
+
+
+def test_matching_integer_transcript_length_labels_are_accepted():
+    counts, metadata, transcript_lengths = small_tximport_data()
+    integer_samples = pd.Index(range(1, len(counts) + 1))
+    integer_genes = pd.Index(range(101, 101 + counts.shape[1]))
+    counts.index = integer_samples
+    counts.columns = integer_genes
+    metadata.index = integer_samples
+    transcript_lengths.index = integer_samples
+    transcript_lengths.columns = integer_genes
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ad.ImplicitModificationWarning)
+        dds = DeseqDataSet(
+            counts=counts,
+            metadata=metadata,
+            transcript_lengths=transcript_lengths,
+            quiet=True,
+        )
+
+    np.testing.assert_allclose(
+        dds.layers["avg_tx_length"], transcript_lengths.to_numpy()
+    )
+
+
+def test_scalar_size_factor_refit_clears_stale_matrix_factors():
+    counts, metadata, _ = small_tximport_data()
+    counts = counts.round().astype(int)
+    dds = DeseqDataSet(counts=counts, metadata=metadata, quiet=True)
+    dds.layers["normalization_factors"] = np.full(dds.shape, 2.0)
+
+    dds.fit_size_factors()
+
+    assert "normalization_factors" not in dds.layers
+    np.testing.assert_allclose(
+        dds.layers["normed_counts"],
+        dds.X / dds.obs["size_factors"].to_numpy()[:, None],
+    )
+
+
+def test_cooks_outlier_refit_preserves_matrix_factors():
+    counts = load_example_data("raw_counts", "synthetic", debug=False)
+    metadata = load_example_data("metadata", "synthetic", debug=False)
+    counts.iloc[0, 0] *= 10_000
+    transcript_lengths = varying_transcript_lengths(counts)
+
+    dds = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        transcript_lengths=transcript_lengths,
+        design="~0 + condition",
+        fit_type="mean",
+        refit_cooks=True,
+        min_replicates=3,
+        n_cpus=1,
+        quiet=True,
+    )
+    dds.deseq2()
+
+    assert dds.var["replaced"].sum() == 1
+    assert dds.var["refitted"].sum() == 1
+    refitted = dds.var["refitted"].to_numpy()
+    np.testing.assert_allclose(
+        dds.counts_to_refit.layers["normalization_factors"],
+        dds.layers["normalization_factors"][:, refitted],
+    )
+    assert np.isfinite(dds.varm["LFC"].loc[dds.var_names[refitted]].to_numpy()).all()

--- a/tests/test_transcript_length_normalization.py
+++ b/tests/test_transcript_length_normalization.py
@@ -4,6 +4,7 @@ import anndata as ad
 import numpy as np
 import pandas as pd
 import pytest
+from scipy.sparse import csc_matrix
 from scipy.sparse import csr_matrix
 
 from pydeseq2.dds import DeseqDataSet
@@ -44,6 +45,18 @@ def small_tximport_data():
         columns=genes,
     )
     return counts, metadata, transcript_lengths
+
+
+def small_pytximport_adata():
+    counts, metadata, transcript_lengths = small_tximport_data()
+    adata = ad.AnnData(
+        X=counts.to_numpy(),
+        obs=metadata.copy(),
+        var=pd.DataFrame(index=counts.columns),
+    )
+    adata.obsm["length"] = transcript_lengths.to_numpy()
+    adata.uns["counts_from_abundance"] = None
+    return adata, counts, metadata, transcript_lengths
 
 
 def varying_transcript_lengths(counts):
@@ -170,12 +183,30 @@ def test_external_vst_transform_requires_matching_transcript_lengths():
         dds.vst_transform(dds.X)
 
 
-def test_transcript_length_factors_are_used_throughout_pipeline():
+@pytest.mark.parametrize("sparse_constructor", [csr_matrix, csc_matrix])
+def test_transcript_length_factors_are_used_throughout_pipeline(
+    monkeypatch, sparse_constructor
+):
     counts = load_example_data("raw_counts", "synthetic", debug=False)
     metadata = load_example_data("metadata", "synthetic", debug=False)
     transcript_lengths = varying_transcript_lengths(counts)
+    adata = ad.AnnData(
+        X=sparse_constructor(counts.to_numpy()),
+        obs=metadata,
+        var=pd.DataFrame(index=counts.columns),
+    )
+    adata.obsm["length"] = transcript_lengths.to_numpy()
+    adata.uns["counts_from_abundance"] = None
 
     dds = DeseqDataSet(
+        adata=adata,
+        design="~0 + condition",
+        fit_type="mean",
+        refit_cooks=False,
+        n_cpus=1,
+        quiet=True,
+    )
+    reference_dds = DeseqDataSet(
         counts=counts,
         metadata=metadata,
         transcript_lengths=transcript_lengths,
@@ -186,6 +217,14 @@ def test_transcript_length_factors_are_used_throughout_pipeline():
         quiet=True,
     )
     dds.deseq2()
+    reference_dds.deseq2()
+
+    dispersion_columns = ["_MoM_dispersions", "genewise_dispersions", "dispersions"]
+    np.testing.assert_allclose(
+        dds.var[dispersion_columns].to_numpy(),
+        reference_dds.var[dispersion_columns].to_numpy(),
+    )
+    np.testing.assert_allclose(dds.varm["LFC"], reference_dds.varm["LFC"])
 
     non_zero = dds.var["non_zero"].to_numpy()
     normalization_factors = dds.layers["normalization_factors"][:, non_zero]
@@ -198,13 +237,32 @@ def test_transcript_length_factors_are_used_throughout_pipeline():
     np.testing.assert_allclose(dds.obsm["_mu_LFC"], expected_mu)
 
     stats = DeseqStats(dds, contrast=["condition", "B", "A"], quiet=True)
+    reference_stats = DeseqStats(
+        reference_dds, contrast=["condition", "B", "A"], quiet=True
+    )
     stats.summary()
+    reference_stats.summary()
     assert stats.results_df["pvalue"].notna().any()
+    np.testing.assert_allclose(
+        stats.results_df[["stat", "pvalue", "lfcSE"]],
+        reference_stats.results_df[["stat", "pvalue", "lfcSE"]],
+        equal_nan=True,
+    )
 
     coefficient = stats.LFC.columns[-1]
     stats.lfc_shrink(coeff=coefficient, adapt=False)
+    reference_stats.lfc_shrink(coeff=coefficient, adapt=False)
     assert stats.shrunk_LFCs
-    assert stats.LFC[coefficient].notna().any()
+    np.testing.assert_allclose(
+        stats.LFC[coefficient], reference_stats.LFC[coefficient], equal_nan=True
+    )
+    monkeypatch.setattr(dds, "fit_size_factors", lambda *args, **kwargs: pytest.fail())
+    dds.vst(fit_type="mean")
+    reference_dds.vst(fit_type="mean")
+    np.testing.assert_allclose(
+        dds.layers["vst_counts"], reference_dds.layers["vst_counts"]
+    )
+    assert isinstance(dds.X, sparse_constructor)
 
 
 def test_moments_dispersions_match_deseq2_with_matrix_factors():
@@ -244,6 +302,29 @@ def test_sparse_anndata_with_stored_transcript_lengths():
 
     np.testing.assert_array_equal(dds.X.toarray(), np.rint(counts.to_numpy()))
     assert "normalization_factors" in dds.layers
+    np.testing.assert_array_equal(adata.X.toarray(), counts.to_numpy())
+    np.testing.assert_allclose(
+        adata.layers["avg_tx_length"], transcript_lengths.to_numpy()
+    )
+    assert "design_matrix" not in adata.obsm
+    assert "normalization_factors" not in adata.layers
+    assert "normed_counts" not in adata.layers
+
+
+def test_sparse_estimated_counts_round_after_summing_duplicates():
+    counts = csr_matrix(
+        (np.array([0.4, 0.4, 0.4]), np.array([0, 0, 1]), np.array([0, 2, 3])),
+        shape=(2, 2),
+    )
+    adata = ad.AnnData(X=counts)
+    adata.obsm["length"] = np.ones((2, 2))
+    adata.uns["counts_from_abundance"] = None
+
+    dds = DeseqDataSet(adata=adata, design="~1", quiet=True)
+
+    np.testing.assert_array_equal(dds.X.toarray(), np.array([[1, 0], [0, 0]]))
+    assert dds.X.nnz == 1
+    assert adata.X.nnz == 3
 
 
 def test_matching_integer_transcript_length_labels_are_accepted():
@@ -285,13 +366,30 @@ def test_scalar_size_factor_refit_clears_stale_matrix_factors():
     )
 
 
-def test_cooks_outlier_refit_preserves_matrix_factors():
+@pytest.mark.parametrize("sparse_constructor", [csr_matrix, csc_matrix])
+def test_cooks_outlier_refit_preserves_matrix_factors(sparse_constructor):
     counts = load_example_data("raw_counts", "synthetic", debug=False)
     metadata = load_example_data("metadata", "synthetic", debug=False)
     counts.iloc[0, 0] *= 10_000
     transcript_lengths = varying_transcript_lengths(counts)
+    adata = ad.AnnData(
+        X=sparse_constructor(counts.to_numpy()),
+        obs=metadata,
+        var=pd.DataFrame(index=counts.columns),
+    )
+    adata.obsm["length"] = transcript_lengths.to_numpy()
+    adata.uns["counts_from_abundance"] = None
 
     dds = DeseqDataSet(
+        adata=adata,
+        design="~0 + condition",
+        fit_type="mean",
+        refit_cooks=True,
+        min_replicates=3,
+        n_cpus=1,
+        quiet=True,
+    )
+    reference_dds = DeseqDataSet(
         counts=counts,
         metadata=metadata,
         transcript_lengths=transcript_lengths,
@@ -303,12 +401,224 @@ def test_cooks_outlier_refit_preserves_matrix_factors():
         quiet=True,
     )
     dds.deseq2()
+    reference_dds.deseq2()
 
     assert dds.var["replaced"].sum() == 1
     assert dds.var["refitted"].sum() == 1
+    np.testing.assert_array_equal(
+        dds.var[["replaced", "refitted"]],
+        reference_dds.var[["replaced", "refitted"]],
+    )
+    np.testing.assert_allclose(
+        dds.layers["cooks"],
+        reference_dds.layers["cooks"],
+        rtol=1e-7,
+        atol=1e-10,
+        equal_nan=True,
+    )
+    np.testing.assert_array_equal(dds.counts_to_refit.X, reference_dds.counts_to_refit.X)
     refitted = dds.var["refitted"].to_numpy()
     np.testing.assert_allclose(
         dds.counts_to_refit.layers["normalization_factors"],
         dds.layers["normalization_factors"][:, refitted],
     )
-    assert np.isfinite(dds.varm["LFC"].loc[dds.var_names[refitted]].to_numpy()).all()
+    np.testing.assert_allclose(
+        dds.var.loc[refitted, ["genewise_dispersions", "dispersions"]],
+        reference_dds.var.loc[refitted, ["genewise_dispersions", "dispersions"]],
+    )
+    np.testing.assert_allclose(
+        dds.varm["LFC"].loc[dds.var_names[refitted]],
+        reference_dds.varm["LFC"].loc[reference_dds.var_names[refitted]],
+    )
+    assert isinstance(dds.X, sparse_constructor)
+
+
+@pytest.mark.parametrize("sparse_counts", [False, True])
+def test_pytximport_anndata_matches_explicit_transcript_lengths(sparse_counts):
+    adata, counts, metadata, transcript_lengths = small_pytximport_adata()
+    if sparse_counts:
+        adata.X = csr_matrix(adata.X)
+
+    pytximport_dds = DeseqDataSet(adata=adata, design="~condition", quiet=True)
+    explicit_dds = DeseqDataSet(
+        counts=counts,
+        metadata=metadata,
+        transcript_lengths=transcript_lengths,
+        design="~condition",
+        quiet=True,
+    )
+    pytximport_dds.fit_size_factors()
+    explicit_dds.fit_size_factors()
+
+    pytximport_counts = pytximport_dds.X.toarray() if sparse_counts else pytximport_dds.X
+    np.testing.assert_array_equal(pytximport_counts, explicit_dds.X)
+    np.testing.assert_allclose(
+        pytximport_dds.layers["avg_tx_length"],
+        explicit_dds.layers["avg_tx_length"],
+    )
+    np.testing.assert_allclose(
+        pytximport_dds.obs["size_factors"], explicit_dds.obs["size_factors"]
+    )
+    np.testing.assert_allclose(
+        pytximport_dds.layers["normalization_factors"],
+        explicit_dds.layers["normalization_factors"],
+    )
+    np.testing.assert_allclose(
+        pytximport_dds.layers["normed_counts"],
+        explicit_dds.layers["normed_counts"],
+    )
+    assert isinstance(pytximport_dds.X, csr_matrix) is sparse_counts
+
+
+def test_pytximport_backed_anndata_requires_memory(tmp_path):
+    adata = ad.AnnData(X=np.ones((2, 2)))
+    adata.obsm["length"] = np.ones((2, 2))
+    adata.uns["counts_from_abundance"] = None
+    path = tmp_path / "backed.h5ad"
+    adata.write_h5ad(path)
+    backed = ad.read_h5ad(path, backed="r")
+
+    try:
+        with pytest.raises(ValueError, match="to_memory"):
+            DeseqDataSet(adata=backed, quiet=True)
+    finally:
+        backed.file.close()
+
+
+def test_pytximport_dataframe_length_labels_are_preserved():
+    adata, _, _, transcript_lengths = small_pytximport_adata()
+    adata.obsm["length"] = transcript_lengths.copy()
+
+    dds = DeseqDataSet(adata=adata, quiet=True)
+
+    assert dds.obs_names.equals(transcript_lengths.index)
+    assert dds.var_names.equals(transcript_lengths.columns)
+    np.testing.assert_allclose(
+        dds.layers["avg_tx_length"], transcript_lengths.to_numpy()
+    )
+
+
+def test_pytximport_dataframe_gene_labels_must_match():
+    adata, _, _, transcript_lengths = small_pytximport_adata()
+    adata.obsm["length"] = transcript_lengths.rename(columns={"gene1": "wrong_gene"})
+
+    with pytest.raises(ValueError, match="same gene columns"):
+        DeseqDataSet(adata=adata, quiet=True)
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "scaled_tpm",
+        "length_scaled_tpm",
+        "dtu_scaled_tpm",
+        "scaledTPM",
+        "lengthScaledTPM",
+    ],
+)
+def test_pytximport_scaled_count_modes_are_rejected(mode):
+    adata, _, _, _ = small_pytximport_adata()
+    adata.uns["counts_from_abundance"] = mode
+
+    with pytest.raises(ValueError, match="unscaled estimated counts"):
+        DeseqDataSet(adata=adata, quiet=True)
+
+
+@pytest.mark.parametrize("higher_precedence_source", ["explicit", "canonical"])
+def test_scaled_pytximport_mode_rejects_higher_precedence_lengths(
+    higher_precedence_source,
+):
+    adata, _, _, transcript_lengths = small_pytximport_adata()
+    adata.uns["counts_from_abundance"] = "length_scaled_tpm"
+    del adata.obsm["length"]
+    explicit_lengths = None
+    if higher_precedence_source == "explicit":
+        explicit_lengths = transcript_lengths
+    else:
+        adata.layers["avg_tx_length"] = transcript_lengths.to_numpy()
+
+    with pytest.raises(ValueError, match="must not be combined"):
+        DeseqDataSet(
+            adata=adata,
+            transcript_lengths=explicit_lengths,
+            quiet=True,
+        )
+
+
+@pytest.mark.parametrize("bad_value", [0.0, np.nan, np.inf])
+def test_pytximport_lengths_must_be_positive_and_finite(bad_value):
+    adata, _, _, _ = small_pytximport_adata()
+    lengths = adata.obsm["length"].copy()
+    lengths[0, 0] = bad_value
+    adata.obsm["length"] = lengths
+
+    with pytest.raises(ValueError, match="transcript_lengths"):
+        DeseqDataSet(adata=adata, quiet=True)
+
+
+def test_pytximport_lengths_reject_unsynchronized_gene_subsetting():
+    adata, _, _, _ = small_pytximport_adata()
+    subset = adata[:, :2].copy()
+
+    with pytest.raises(ValueError, match="same shape"):
+        DeseqDataSet(adata=subset, quiet=True)
+
+
+@pytest.mark.parametrize("use_explicit_lengths", [False, True])
+def test_transcript_length_source_precedence(use_explicit_lengths):
+    adata, _, _, transcript_lengths = small_pytximport_adata()
+    canonical_lengths = transcript_lengths.to_numpy() + 100.0
+    explicit_lengths = transcript_lengths + 200.0
+    adata.layers["avg_tx_length"] = canonical_lengths
+
+    dds = DeseqDataSet(
+        adata=adata,
+        transcript_lengths=explicit_lengths if use_explicit_lengths else None,
+        quiet=True,
+    )
+
+    expected = explicit_lengths.to_numpy() if use_explicit_lengths else canonical_lengths
+    np.testing.assert_allclose(dds.layers["avg_tx_length"], expected)
+
+
+def test_pytximport_length_without_mode_is_not_auto_detected():
+    adata, counts, _, _ = small_pytximport_adata()
+    del adata.uns["counts_from_abundance"]
+    adata.X = np.rint(counts.to_numpy())
+
+    dds = DeseqDataSet(adata=adata, quiet=True)
+
+    assert "avg_tx_length" not in dds.layers
+
+
+def test_counts_from_abundance_without_lengths_is_not_pytximport():
+    adata, counts, _, _ = small_pytximport_adata()
+    del adata.obsm["length"]
+    adata.X = np.rint(counts.to_numpy())
+    adata.uns["counts_from_abundance"] = "scaled_tpm"
+
+    dds = DeseqDataSet(adata=adata, quiet=True)
+
+    assert "avg_tx_length" not in dds.layers
+
+
+def test_pytximport_input_anndata_is_not_mutated():
+    adata, counts, _, transcript_lengths = small_pytximport_adata()
+    original_obs = adata.obs.copy()
+    connectivities = np.eye(adata.n_obs)
+    adata.uns["neighbors"] = {"connectivities": connectivities}
+
+    dds = DeseqDataSet(adata=adata, quiet=True)
+    dds.fit_size_factors()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        picklable_adata = dds.to_picklable_anndata()
+
+    np.testing.assert_array_equal(adata.X, counts.to_numpy())
+    pd.testing.assert_frame_equal(adata.obs, original_obs)
+    assert dds.var is not adata.var
+    assert adata.uns["neighbors"]["connectivities"] is connectivities
+    assert "connectivities" in picklable_adata.obsp
+    np.testing.assert_array_equal(adata.obsm["length"], transcript_lengths.to_numpy())
+    assert "design_matrix" not in adata.obsm
+    assert not adata.layers

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,9 +3,20 @@ from unittest import mock
 
 import numpy as np
 import pytest
+from scipy.sparse import bsr_array
+from scipy.sparse import bsr_matrix
+from scipy.sparse import coo_array
+from scipy.sparse import coo_matrix
+from scipy.sparse import dia_array
+from scipy.sparse import dia_matrix
+from scipy.sparse import dok_array
+from scipy.sparse import dok_matrix
+from scipy.sparse import lil_array
+from scipy.sparse import lil_matrix
 
 from pydeseq2.utils import load_example_data
 from pydeseq2.utils import nb_nll
+from pydeseq2.utils import test_valid_counts as validate_counts
 
 
 @pytest.mark.parametrize("mu, alpha", [(10, 0.5), (10, 0.1), (3, 0.5), (9, 0.05)])
@@ -53,3 +64,41 @@ def test_rtd_example_data_loading(mocked_function, modality, mocked_dir_flag):
         dataset="synthetic",
         debug=False,
     )
+
+
+@pytest.mark.parametrize(
+    "sparse_constructor",
+    [
+        bsr_matrix,
+        coo_matrix,
+        dia_matrix,
+        dok_matrix,
+        lil_matrix,
+        bsr_array,
+        coo_array,
+        dia_array,
+        dok_array,
+        lil_array,
+    ],
+)
+def test_valid_sparse_count_formats(sparse_constructor):
+    validate_counts(sparse_constructor([[1, 0], [0, 2]]))
+
+
+@pytest.mark.parametrize("sparse_constructor", [dia_matrix, dia_array])
+def test_valid_dia_counts_ignore_padding(sparse_constructor):
+    counts = sparse_constructor(
+        (np.array([[-1, 2]]), np.array([1])),
+        shape=(2, 2),
+    )
+    np.testing.assert_array_equal(counts.toarray(), [[0, 2], [0, 0]])
+    validate_counts(counts)
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [(np.nan, "NaNs"), (1.5, "integers"), (-1, "non-negative")],
+)
+def test_invalid_general_sparse_counts(value, message):
+    with pytest.raises(ValueError, match=message):
+        validate_counts(dok_matrix([[value]]))


### PR DESCRIPTION
#### Reference Issue or PRs

  Closes #305.
  Closes #359.
  Related to #412.

  #### What does your PR implement? Be specific.

  This PR adds DESeq2-style transcript-length
  normalization and direct compatibility
  with AnnData objects produced by
  [`pytximport`](https://github.com/complextissue/
  pytximport).

  The generic API remains available:

  ```python
  dds = DeseqDataSet(
      counts=estimated_counts,
      metadata=metadata,
      transcript_lengths=average_transcript_lengths,
      design="~condition",
  )
  ```

  Compatible pytximport objects can also be passed
  directly:

  ```python
  dds = DeseqDataSet(adata=txi, design="~condition")
  ```

  The implementation:

  - Rounds unscaled estimated counts, matching
  DESeq2.
  - Stores average transcript lengths in
  `layers["avg_tx_length"]`.
  - Constructs sample-by-gene normalization factors
  containing both transcript-length
    and relative library-size components.
  - Stores the final factors in
  `layers["normalization_factors"]`.
  - Uses the factor matrix throughout dispersion
  fitting, LFC fitting, Wald tests,
    shrinkage, Cook's outlier replacement/refitting,
    and VST.
  - Supports the `ratio` and `poscounts` size-factor
  methods.
  - Preserves sparse CSR and CSC counts through
  inference boundaries.
  - Does not add `pytximport` as a runtime
  dependency.

  Length-source precedence is deterministic:

  1. Explicit `transcript_lengths`
  2. `adata.layers["avg_tx_length"]`
  3. Compatible pytximport fields

  For pytximport input, only unscaled estimated
  counts with
  `adata.uns["counts_from_abundance"] is None` are
  accepted. Abundance-scaled modes
  are rejected to prevent applying transcript-length
  correction twice.

  #### Validation

  Local verification completed successfully:

  - Full test suite: 104 passed
  - Dense-versus-CSR/CSC parity through dispersion
  fitting, LFCs, Wald tests,
    shrinkage, VST, Cook's distances, replacement,
    and refitting
  - AnnData 0.11.4 compatibility checks passed
  - Ruff, formatting, mypy, pre-commit, and Sphinx
  warnings-as-errors passed

  #### Current limitations

  - Direct pytximport normalization requires an in-
  memory AnnData object.
  - Pytximport's current `obsm["length"]` matrix has
  no gene-axis labels, so it must
    remain synchronized when genes are subset or
    reordered.
  - Iterative size-factor fitting is not supported
  with transcript-length offsets.
  - VST transformation of an external count matrix
  with separate transcript lengths
    is not currently supported.

  #### Related work and acknowledgements

  This implementation began independently with the
  generic `transcript_lengths`
  API and was extended with direct pytximport
  compatibility following discussion in
  #412.

  Thank you to @maltekuehl for the earlier draft
  implementation and design work in
  #412, and to @Zethson for encouraging this work to
  be taken forward. The original
  tximport, DESeq2, and pytximport work is credited
  in the documentation.
