### PR TITLE
Align minimum supported dependencies with SPEC 0

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -19,8 +19,6 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: "3.11"
-          - os: ubuntu-latest
             python: "3.12"
           - os: ubuntu-latest
             python: "3.13"

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ If you're interested in contributing or want access to the development version, 
 The list of package version requirements is available in `pyproject.toml`.
 
 For reference, the code is being tested in a github workflow (CI) with python
-3.11 to 3.13 and the latest versions of the following packages:
+3.12 to 3.13 and the latest versions of the following packages:
 
 ```
 - anndata

--- a/docs/source/usage/requirements.rst
+++ b/docs/source/usage/requirements.rst
@@ -1,17 +1,18 @@
 Requirements
 ------------
 
-The list of package version requirements is available in ``setup.py``, and will be automatically installed along PyDESeq2 when using PyPI.
-For reference, the code was tested with python 3.11 and the following package versions::
+The list of package version requirements is available in ``pyproject.toml``, and will be automatically installed along PyDESeq2 when using PyPI.
+For reference, the code was tested with python 3.12 and the following package versions::
 
     - anndata>=0.11.0
     - formulaic>=1.0.2
-    - numpy>=2.0.0
-    - pandas>=2.2.0
-    - scikit-learn>=1.4.0
-    - scipy>=1.12.0
+    - numpy>=2.2.0
+    - pandas>=2.3.0
+    - scikit-learn>=1.6.0
+    - scipy>=1.15.0
     - formulaic-contrasts>=0.2.0
-    - matplotlib>=3.9.0
+    - matplotlib>=3.10.0
 
-Note that starting from pydeseq2 0.5.3, python 3.10 is no longer supported.
+Minimum supported versions of Python and the core scientific Python packages follow `SPEC 0 <https://scientific-python.org/specs/spec-0000/>`_.
+Python versions are dropped 3 years after their initial release, and core package versions 2 years after theirs.
 Please don't hesitate to open an issue in case you encounter any problems due to possible deprecations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,22 +17,21 @@ authors = [
   { name = "Vincent Cabelli" },
   { name = "Mathieu Andreux" },
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
   "anndata>=0.11.0",
   "formulaic>=1.0.2",
-  "numpy>=2.0.0",
-  "pandas>=2.2.0",
-  "scikit-learn>=1.4.0",
-  "scipy>=1.12.0",
+  "numpy>=2.2.0",
+  "pandas>=2.3.0",
+  "scikit-learn>=1.6.0",
+  "scipy>=1.15.0",
   "formulaic-contrasts>=0.2.0",
-  "matplotlib>=3.9.0",
+  "matplotlib>=3.10.0",
 ]
 optional-dependencies.dev = [
   "pytest>=8.4.0",


### PR DESCRIPTION
Applies the [SPEC 0](https://scientific-python.org/specs/spec-0000/) drop schedule as of 2026 Q3, raising the floors to Python 3.12, numpy 2.2, scipy 1.15, pandas 2.3, scikit-learn 1.6 and matplotlib 3.10, and drops Python 3.11 from the CI matrix.
The test suite passes on Python 3.12 both at the new floors and against current releases of every dependency; anndata, formulaic and formulaic-contrasts are not SPEC 0 core packages so their floors are untouched.