### PR TITLE
Move test dependencies into a `test` dependency group

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -38,7 +38,7 @@ jobs:
           version: "latest"
       - name: Install dependencies
         run: |
-          uv sync --extra doc --extra dev
+          uv sync --extra doc --extra dev --group test
       - name: Lint with ruff
         run: |
           uv run ruff check --fix --exit-non-zero-on-fix pydeseq2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,8 @@ dependencies = [
   "matplotlib>=3.9.0",
 ]
 optional-dependencies.dev = [
-  "pytest>=8.4.0",
   "pre-commit>=2.16.0",
   "numpydoc",
-  "coverage",
   "mypy==1.18.2",
   "pandas-stubs",
   "ruff==0.14.0",
@@ -63,6 +61,12 @@ optional-dependencies.doc = [
 urls.Documentation = "https://pydeseq2.readthedocs.io/"
 urls.Homepage = "https://github.com/owkin/PyDESeq2"
 urls.Source = "https://github.com/owkin/PyDESeq2"
+
+[dependency-groups]
+test = [
+  "coverage",
+  "pytest>=8.4.0",
+]
 
 [tool.ruff]
 line-length = 89


### PR DESCRIPTION
pytest and coverage were part of the `dev` extra, so running just the test suite meant pulling in the linters, type checker and stubs as well. A `test` dependency group separates the two, and matches the convention the rest of the scverse packages follow, which lets tooling install a testable environment with `--group test` without guessing at an extra name.

CI syncs the new group alongside the existing extras, so it installs the same set of packages as before.

