### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @BorisMuzellec @maikia @umarteauowkin


### PR DESCRIPTION
Every PR automatically requested a review from the three owkin maintainers listed in CODEOWNERS, who are no longer the repository's default reviewers now that it sits under scverse. Branch protection does not require code owner reviews, so this only drops the automatic request.