### PR TITLE
Remove duplicated types from docstrings

### DIFF
--- a/examples/plot_minimal_pydeseq2_pipeline.py
+++ b/examples/plot_minimal_pydeseq2_pipeline.py
@@ -2,8 +2,7 @@
 A simple PyDESeq2 workflow
 ===========================
 
-In this example, we show how to perform a simple differential expression analysis on bulk
-RNAseq data, using PyDESeq2.
+In this example, we show how to perform a simple differential expression analysis on bulk RNAseq data, using PyDESeq2.
 
 .. contents:: Contents
     :local:

--- a/examples/plot_pandas_io_example.py
+++ b/examples/plot_pandas_io_example.py
@@ -2,12 +2,9 @@
 Loading data and saving results with pandas and pickle
 ======================================================
 
-In this example, we show how load data in order to perform a DEA analysis with PyDESeq2,
-and how to save its results, using `pandas <https://pandas.pydata.org/>`_ and
-`pickle <https://docs.python.org/3/library/pickle.html>`_.
+In this example, we show how load data in order to perform a DEA analysis with PyDESeq2, and how to save its results, using `pandas <https://pandas.pydata.org/>`_ and `pickle <https://docs.python.org/3/library/pickle.html>`_.
 
-We refer to the :doc:`getting started example <plot_minimal_pydeseq2_pipeline>` for more
-details on the analysis itself.
+We refer to the :doc:`getting started example <plot_minimal_pydeseq2_pipeline>` for more details on the analysis itself.
 
 .. contents:: Contents
     :local:

--- a/examples/plot_step_by_step.py
+++ b/examples/plot_step_by_step.py
@@ -4,18 +4,15 @@ Step-by-step PyDESeq2 workflow
 
 This notebook details all the steps of the PyDESeq2 pipeline.
 
-It allows you to run the PyDESeq2 pipeline on the synthetic data provided
-in this repository.
+It allows you to run the PyDESeq2 pipeline on the synthetic data provided in this repository.
 
-If this is your first contact with PyDESeq2, we recommend you first have a look at the
-:doc:`standard workflow example <plot_minimal_pydeseq2_pipeline>`.
+If this is your first contact with PyDESeq2, we recommend you first have a look at the :doc:`standard workflow example <plot_minimal_pydeseq2_pipeline>`.
 
 .. contents:: Contents
     :local:
     :depth: 3
 
-We start by importing required packages and setting up an optional path to save
-results.
+We start by importing required packages and setting up an optional path to save results.
 """
 
 import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ lint.ignore = [
   # Disable one in each pair of mutually incompatible rules
   "D203", # We don't want a blank line before a class docstring
   "D213", # We want docstrings to start immediately after the opening triple quote
+  "E501", # Line too long
 ]
 lint.per-file-ignores."*/__init__.py" = [ "F401" ]
 lint.per-file-ignores."docs/*" = [ "I" ]

--- a/src/pydeseq2/datasets.py
+++ b/src/pydeseq2/datasets.py
@@ -16,32 +16,25 @@ def load_example_data(
 ) -> pd.DataFrame:
     """Load synthetic example data.
 
-    May load either metadata or rna-seq data. For now, this function may only return the
-    synthetic data provided as part of this repo, but new datasets might be added in the
-    future.
+    May load either metadata or rna-seq data.
+    For now, this function may only return the synthetic data provided as part of this repo, but new datasets might be added in the future.
 
     Parameters
     ----------
-    modality : str
+    modality
         Data modality. "raw_counts" or "metadata".
-
-    dataset : str
+    dataset
         The dataset for which to return gene expression data.
-        If "synthetic", will return the synthetic data that is used for CI unit tests.
-        (default: ``"synthetic"``).
-
-    debug : bool
+        If "synthetic", will return the synthetic data that is used for CI unit tests. (default: ``"synthetic"``).
+    debug
         If true, subsample 10 samples and 100 genes at random.
-        (Note that the "synthetic" dataset is already 10 features 100.)
-        (default: ``False``).
-
-    debug_seed : int
+        (Note that the "synthetic" dataset is already 10 features 100.) (default: ``False``).
+    debug_seed
         Seed for the debug mode. (default: ``42``).
 
     Returns
     -------
-    pandas.DataFrame
-        Requested data modality.
+    Requested data modality.
     """
     assert modality in [
         "raw_counts",

--- a/src/pydeseq2/dds.py
+++ b/src/pydeseq2/dds.py
@@ -36,168 +36,112 @@ warnings.simplefilter("ignore", FutureWarning)
 class DeseqDataSet(ad.AnnData):
     r"""A class to implement dispersion and log fold-change (LFC) estimation.
 
-    The DeseqDataSet extends the `AnnData class
-    <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.html#anndata.AnnData>`_.
-    As such, it implements the same methods and attributes, in addition to those that are
-    specific to pydeseq2.
-    Dispersions and LFCs are estimated following the DESeq2 pipeline
-    :cite:p:`DeseqDataSet-love2014moderated`.
+    The DeseqDataSet extends the `AnnData class <https://anndata.readthedocs.io/en/latest/generated/anndata.AnnData.html#anndata.AnnData>`_.
+    As such, it implements the same methods and attributes, in addition to those that are specific to pydeseq2.
+    Dispersions and LFCs are estimated following the DESeq2 pipeline :cite:p:`DeseqDataSet-love2014moderated`.
 
     Parameters
     ----------
-    adata : anndata.AnnData
-        AnnData from which to initialize the DeseqDataSet. Must have counts ('X') and
-        sample metadata ('obs') fields. If ``None``, both ``counts`` and ``metadata``
-        arguments must be provided.
-
-    counts : pandas.DataFrame
-        Raw counts. One column per gene, rows are indexed by sample barcodes.
-
-    metadata : pandas.DataFrame
+    adata
+        AnnData from which to initialize the DeseqDataSet.
+        Must have counts ('X') and sample metadata ('obs') fields.
+        If ``None``, both ``counts`` and ``metadata`` arguments must be provided.
+    counts
+        Raw counts.
+        One column per gene, rows are indexed by sample barcodes.
+    metadata
         DataFrame containing sample metadata.
         Must be indexed by sample barcodes.
-
-    design : str or pandas.DataFrame
-        Model design. Can be either a pandas DataFrame representing a design matrix, or
-        a formulaic formula in the format ``'x + z'`` or ``'~x+z'``.
-        If a design matrix is provided, DeseqStats built from this DeseqDataSet will
-        only support contrasts in the form of numeric vectors.
+    design
+        Model design.
+        Can be either a pandas DataFrame representing a design matrix, or a formulaic formula in the format ``'x + z'`` or ``'~x+z'``.
+        If a design matrix is provided, DeseqStats built from this DeseqDataSet will only support contrasts in the form of numeric vectors.
         (Default: ``'~condition')``.
-
-    design_factors : str or list, optional
-        Depecated. An optional list of factors to include in the design matrix.
+    design_factors
+        Depecated.
+        An optional list of factors to include in the design matrix.
         Will be removed in a future release. (default: ``None``).
-
-    continuous_factors : list, optional
-        Deprecated. Continuous factors are now automatically detected from the design,
-        or cast to categorical using the C() operator in the formula.
-        (default: ``None``).
-
-    ref_level : list, optional
+    continuous_factors
         Deprecated.
-
-    fit_type: str
-        Either ``"parametric"`` or ``"mean"`` for the type of fitting of dispersions to
-        the mean intensity. ``"parametric"``: fit a dispersion-mean relation via a
-        robust gamma-family GLM. ``"mean"``: use the mean of gene-wise dispersion
-        estimates. Will set the fit type for the DEA and the vst transformation. If
-        needed, it can be set separately for each method.(default: ``"parametric"``).
-
-    size_factors_fit_type : str
-        The normalization method to use: ``"ratio"``, ``"poscounts"`` or ``"iterative"``.
-        ``"ratio"``: fit size factors using the median-of-ratios method. ``"poscounts"``:
-        fit size factors using the method implemented in DESeq2 for the case where there
-        may be few or no genes which have no zero values.
-        ``"iterative"``: fit size factors iteratively. (default: ``"ratio"``).
-
-    control_genes : ndarray, list, or pandas.Index, optional
-        Genes to use as control genes for size factor fitting. If provided, size factors
-        will be fit using only these genes. This is useful when certain genes are known
-        to be invariant across conditions (e.g., housekeeping genes). Any valid AnnData
-        indexer (bool array, integer positions, or gene name strings) can be used.
-        (default: ``None``).
-
-    min_mu : float
+        Continuous factors are now automatically detected from the design, or cast to categorical using the C() operator in the formula. (default: ``None``).
+    ref_level
+        Deprecated.
+    fit_type
+        Either ``"parametric"`` or ``"mean"`` for the type of fitting of dispersions to the mean intensity. ``"parametric"``: fit a dispersion-mean relation via a robust gamma-family GLM. ``"mean"``: use the mean of gene-wise dispersion estimates.
+        Will set the fit type for the DEA and the vst transformation.
+        If needed, it can be set separately for each method.(default: ``"parametric"``).
+    size_factors_fit_type
+        The normalization method to use: ``"ratio"``, ``"poscounts"`` or ``"iterative"``. ``"ratio"``: fit size factors using the median-of-ratios method. ``"poscounts"``: fit size factors using the method implemented in DESeq2 for the case where there may be few or no genes which have no zero values. ``"iterative"``: fit size factors iteratively. (default: ``"ratio"``).
+    control_genes
+        Genes to use as control genes for size factor fitting.
+        If provided, size factors will be fit using only these genes.
+        This is useful when certain genes are known to be invariant across conditions (e.g., housekeeping genes).
+        Any valid AnnData indexer (bool array, integer positions, or gene name strings) can be used. (default: ``None``).
+    min_mu
         Threshold for mean estimates. (default: ``0.5``).
-
-    min_disp : float
+    min_disp
         Lower threshold for dispersion parameters. (default: ``1e-8``).
-
-    max_disp : float
+    max_disp
         Upper threshold for dispersion parameters.
-        Note: The threshold that is actually enforced is max(max_disp, len(counts)).
-        (default: ``10``).
-
-    refit_cooks : bool
+        Note: The threshold that is actually enforced is max(max_disp, len(counts)). (default: ``10``).
+    refit_cooks
         Whether to refit cooks outliers. (default: ``True``).
-
-    min_replicates : int
-        Minimum number of replicates a condition should have
-        to allow refitting its samples. (default: ``7``).
-
-    beta_tol : float
+    min_replicates
+        Minimum number of replicates a condition should have to allow refitting its samples. (default: ``7``).
+    beta_tol
         Stopping criterion for IRWLS. (default: ``1e-8``).
 
         .. math:: \vert dev_t - dev_{t+1}\vert / (\vert dev \vert + 0.1) < \beta_{tol}.
-
-    n_cpus : int
-        Number of cpus to use.  If ``None`` and if ``inference`` is not provided, all
-        available cpus will be used by the ``DefaultInference``. If both are specified
-        (i.e., ``n_cpus`` and ``inference`` are not ``None``), it will try to override
-        the ``n_cpus`` attribute of the ``inference`` object. (default: ``None``).
-
-    inference : Inference
-        Implementation of inference routines object instance.
-        (default:
-        :class:`DefaultInference <pydeseq2.default_inference.DefaultInference>`).
-
-    quiet : bool
+    n_cpus
+        Number of cpus to use.
+        If ``None`` and if ``inference`` is not provided, all available cpus will be used by the ``DefaultInference``.
+        If both are specified (i.e., ``n_cpus`` and ``inference`` are not ``None``), it will try to override the ``n_cpus`` attribute of the ``inference`` object. (default: ``None``).
+    inference
+        Implementation of inference routines object instance. (default: :class:`DefaultInference <pydeseq2.default_inference.DefaultInference>`).
+    quiet
         Suppress deseq2 status updates during fit.
-
-    low_memory : bool
-        Remove intermediate data structures from .layers and from .obsm that are no
-        longer necessary after they are used during deseq2 run, such as Cook's
-        distances. (default: False)
+    low_memory
+        Remove intermediate data structures from .layers and from .obsm that are no longer necessary after they are used during deseq2 run, such as Cook's distances. (default: False)
 
     Attributes
     ----------
     X
         A ‘number of samples’ x ‘number of genes’ count data matrix.
-
     obs
-        Key-indexed one-dimensional observations annotation of length 'number of
-        samples". Used to store design factors.
-
+        Key-indexed one-dimensional observations annotation of length 'number of samples".
+        Used to store design factors.
     var
         Key-indexed one-dimensional gene-level annotation of length ‘number of genes’.
-
     uns
         Key-indexed unstructured annotation.
-
     obsm
-        Key-indexed multi-dimensional observations annotation of length
-        ‘number of samples’. Stores "design_matrix" and "size_factors", among others.
-
+        Key-indexed multi-dimensional observations annotation of length ‘number of samples’.
+        Stores "design_matrix" and "size_factors", among others.
     varm
         Key-indexed multi-dimensional gene annotation of length ‘number of genes’.
         Stores "dispersions" and "LFC", among others.
-
     layers
         Key-indexed multi-dimensional arrays aligned to dimensions of `X`, e.g. "cooks".
-
-    n_processes : int
+    n_processes
         Number of cpus to use for multiprocessing.
-
-    non_zero_idx : ndarray
+    non_zero_idx
         Indices of genes that have non-uniformly zero counts.
-
-    non_zero_genes : pandas.Index
+    non_zero_genes
         Index of genes that have non-uniformly zero counts.
-
-    counts_to_refit : anndata.AnnData
-        Read counts after replacement, containing only genes
-        for which dispersions and LFCs must be fitted again.
-
-    new_all_zeroes_genes : pandas.Index
+    counts_to_refit
+        Read counts after replacement, containing only genes for which dispersions and LFCs must be fitted again.
+    new_all_zeroes_genes
         Genes which have only zero counts after outlier replacement.
-
-    quiet : bool
+    quiet
         Suppress deseq2 status updates during fit.
-
-    logmeans: numpy.ndarray
+    logmeans
         Gene-wise mean log counts, computed in ``preprocessing.deseq2_norm_fit()``.
-
-    filtered_genes: numpy.ndarray
-        Genes whose log means are different from -∞, computed in
-        preprocessing.deseq2_norm_fit().
-
-    factor_storage : dict
-        A dictionary storing metadata for each factor processed by the custom
-        materializer (only if ``design`` is input as a formula).
-
-    variable_to_factors : dict
-        A dictionary mapping variable names to factor names (only if ``design`` is input
-        as a formula).
+    filtered_genes
+        Genes whose log means are different from -∞, computed in preprocessing.deseq2_norm_fit().
+    factor_storage
+        A dictionary storing metadata for each factor processed by the custom materializer (only if ``design`` is input as a formula).
+    variable_to_factors
+        A dictionary mapping variable names to factor names (only if ``design`` is input as a formula).
 
     References
     ----------
@@ -372,11 +316,10 @@ class DeseqDataSet(ad.AnnData):
 
         Parameters
         ----------
-        use_design : bool
+        use_design
             Whether to use the full design matrix to fit dispersions and the trend curve.
             If False, only an intercept is used. (default: ``False``).
-
-        fit_type: str
+        fit_type
             * ``None``: fit_type provided at initialization to fit
               the dispersions trend curve.
             * ``"parametric"``: fit a dispersion-mean relation via a robust
@@ -408,11 +351,10 @@ class DeseqDataSet(ad.AnnData):
 
         Parameters
         ----------
-        use_design : bool
+        use_design
             Whether to use the full design matrix to fit dispersions and the trend curve.
             If False, only an intercept is used.
-            Only useful if ``fit_type = "parametric"`.
-            (default: ``False``).
+            Only useful if ``fit_type = "parametric"`. (default: ``False``).
         """
         # Start by fitting median-of-ratio size factors if not already present,
         # or if they were computed iteratively
@@ -457,14 +399,13 @@ class DeseqDataSet(ad.AnnData):
 
         Parameters
         ----------
-        counts : numpy.ndarray
-            Counts to transform. If ``None``, use the counts from the current dataset.
-            (default: ``None``).
+        counts
+            Counts to transform.
+            If ``None``, use the counts from the current dataset. (default: ``None``).
 
         Returns
         -------
-        numpy.ndarray
-            Variance stabilized counts.
+        Variance stabilized counts.
 
         Raises
         ------
@@ -538,14 +479,10 @@ class DeseqDataSet(ad.AnnData):
 
         Parameters
         ----------
-        fit_type : str
-            Either None, ``"parametric"`` or ``"mean"`` for the type of fitting of
-            dispersions to the mean intensity.``"parametric"``: fit a dispersion-mean
-            relation via a robust gamma-family GLM. ``"mean"``: use the mean of
-            gene-wise dispersion estimates.
+        fit_type
+            Either None, ``"parametric"`` or ``"mean"`` for the type of fitting of dispersions to the mean intensity.``"parametric"``: fit a dispersion-mean relation via a robust gamma-family GLM. ``"mean"``: use the mean of gene-wise dispersion estimates.
 
-            If None, the fit_type provided at class initialization is used.
-            (default: ``None``).
+            If None, the fit_type provided at class initialization is used. (default: ``None``).
         """
         if fit_type is not None:
             self.fit_type = fit_type
@@ -589,8 +526,7 @@ class DeseqDataSet(ad.AnnData):
 
         Returns
         -------
-        ndarray
-            A contrast vector that aligns to the columns of the design matrix.
+        A contrast vector that aligns to the columns of the design matrix.
         """
         try:
             return self.formulaic_contrasts.cond(**kwargs)
@@ -619,35 +555,26 @@ class DeseqDataSet(ad.AnnData):
     ) -> None:
         """Fit sample-wise deseq2 normalization (size) factors.
 
-        Uses the median-of-ratios method: see :func:`pydeseq2.preprocessing.deseq2_norm`,
-        unless each gene has at least one sample with zero read counts, in which case it
-        switches to the ``iterative`` method.
+        Uses the median-of-ratios method: see :func:`pydeseq2.preprocessing.deseq2_norm`, unless each gene has at least one sample with zero read counts, in which case it switches to the ``iterative`` method.
 
-        Also available is the 'poscounts' method implemented in DESeq2 for the
-        single-cell or metagenomics use case where there may be few or no features which
-        have no zero values. In this situation, size factors can depend on a very small
-        number of features (or only one feature) leading to incorrect inference. This
-        method for calculating size factors will only exclude genes which have all-0
-        values (and are not amenable to inference anyway).
+        Also available is the 'poscounts' method implemented in DESeq2 for the single-cell or metagenomics use case where there may be few or no features which have no zero values.
+        In this situation, size factors can depend on a very small number of features (or only one feature) leading to incorrect inference.
+        This method for calculating size factors will only exclude genes which have all-0 values (and are not amenable to inference anyway).
 
-        The "poscounts" method calculates the n-th root of the product of the non-zero
-        (positive) counts.
+        The "poscounts" method calculates the n-th root of the product of the non-zero (positive) counts.
 
-        Control genes can be optionally provided; if so, size factors will be fit to
-        only the genes in this argument. This is the same functionality as controlGenes
-        in R DESeq2. Any valid AnnData indexer (bool, int position, var_name string) is
-        accepted.
+        Control genes can be optionally provided; if so, size factors will be fit to only the genes in this argument.
+        This is the same functionality as controlGenes in R DESeq2.
+        Any valid AnnData indexer (bool, int position, var_name string) is accepted.
 
         Parameters
         ----------
-        fit_type : str
-            The normalization method to use: "ratio", "poscounts" or "iterative".
-            (default: ``"ratio"``).
-        control_genes : ndarray, list, or pandas.Index, optional
-            Genes to use as control genes for size factor fitting. If None, all genes
-            are used. Note that manually passing control genes here will override the
-            `DeseqDataSet` `control_genes` attribute.
-            (default: ``None``).
+        fit_type
+            The normalization method to use: "ratio", "poscounts" or "iterative". (default: ``"ratio"``).
+        control_genes
+            Genes to use as control genes for size factor fitting.
+            If None, all genes are used.
+            Note that manually passing control genes here will override the `DeseqDataSet` `control_genes` attribute. (default: ``None``).
         """
         if fit_type is None:
             fit_type = self.size_factors_fit_type
@@ -753,9 +680,8 @@ class DeseqDataSet(ad.AnnData):
 
         Parameters
         ----------
-        vst : bool
-            Whether the dispersion estimates are being fitted as part of the VST
-            pipeline. (default: ``False``).
+        vst
+            Whether the dispersion estimates are being fitted as part of the VST pipeline. (default: ``False``).
         """
         # Check that size factors are available. If not, compute them.
         if "size_factors" not in self.obs:
@@ -839,9 +765,8 @@ class DeseqDataSet(ad.AnnData):
 
         Parameters
         ----------
-        vst : bool
-            Whether the dispersion trend curve is being fitted as part of the VST
-            pipeline. (default: ``False``).
+        vst
+            Whether the dispersion trend curve is being fitted as part of the VST pipeline. (default: ``False``).
         """
         disp_param_name = "vst_genewise_dispersions" if vst else "genewise_dispersions"
         fit_type = self.vst_fit_type if vst else self.fit_type
@@ -880,8 +805,7 @@ class DeseqDataSet(ad.AnnData):
 
         The computation is based on genes whose dispersions are above 100 * min_disp.
 
-        Note: when the design matrix has fewer than 3 degrees of freedom, the
-        estimate of log dispersions is likely to be imprecise.
+        Note: when the design matrix has fewer than 3 degrees of freedom, the estimate of log dispersions is likely to be imprecise.
         """
         # Check that the dispersion trend curve was fitted. If not, fit it.
         if "fitted_dispersions" not in self.var:
@@ -975,8 +899,7 @@ class DeseqDataSet(ad.AnnData):
     def fit_LFC(self) -> None:
         """Fit log fold change (LFC) coefficients.
 
-        In the 2-level setting, the intercept corresponds to the base mean,
-        while the second is the actual LFC coefficient, in natural log scale.
+        In the 2-level setting, the intercept corresponds to the base mean, while the second is the actual LFC coefficient, in natural log scale.
         """
         # Check that MAP dispersions are available. If not, compute them.
         if "dispersions" not in self.var:
@@ -1080,8 +1003,7 @@ class DeseqDataSet(ad.AnnData):
     def refit(self) -> None:
         """Refit Cook outliers.
 
-        Replace values that are filtered out based on the Cooks distance with imputed
-        values, and then re-run the whole DESeq2 pipeline on replaced values.
+        Replace values that are filtered out based on the Cooks distance with imputed values, and then re-run the whole DESeq2 pipeline on replaced values.
         """
         # Replace outlier counts
         self._replace_outliers()
@@ -1150,14 +1072,11 @@ class DeseqDataSet(ad.AnnData):
     def to_picklable_anndata(self) -> ad.AnnData:
         """Convert the DESeqDataSet to a picklable AnnData object.
 
-        Builds an AnnData object from the DESeqDataSet with the same data, but converts
-        the design matrix to a DataFrame to remove the formulaic model_spec attribute,
-        which is not picklable.
+        Builds an AnnData object from the DESeqDataSet with the same data, but converts the design matrix to a DataFrame to remove the formulaic model_spec attribute, which is not picklable.
 
         Returns
         -------
-        anndata.AnnData
-            The AnnData object, without DeseqDataSet unpicklable attributes.
+        The AnnData object, without DeseqDataSet unpicklable attributes.
         """
         # Initialize an AnnData object
         adata = ad.AnnData(
@@ -1206,18 +1125,15 @@ class DeseqDataSet(ad.AnnData):
     ) -> None:
         """Plot dispersions.
 
-        Make a scatter plot with genewise dispersions, trend curve and final (MAP)
-        dispersions.
+        Make a scatter plot with genewise dispersions, trend curve and final (MAP) dispersions.
 
         Parameters
         ----------
-        log : bool
+        log
             Whether to log scale x and y axes (``default=True``).
-
-        save_path : str, optional
-            The path where to save the plot. If left None, the plot won't be saved
-            (``default=None``).
-
+        save_path
+            The path where to save the plot.
+            If left None, the plot won't be saved (``default=None``).
         **kwargs
             Keyword arguments for the scatter plot.
         """
@@ -1243,9 +1159,8 @@ class DeseqDataSet(ad.AnnData):
 
         Parameters
         ----------
-        vst : bool
-            Whether the dispersion trend curve is being fitted as part of the VST
-            pipeline. (default: ``False``).
+        vst
+            Whether the dispersion trend curve is being fitted as part of the VST pipeline. (default: ``False``).
         """
         disp_param_name = "vst_genewise_dispersions" if vst else "genewise_dispersions"
 
@@ -1319,9 +1234,8 @@ class DeseqDataSet(ad.AnnData):
 
         Parameters
         ----------
-        vst : bool
-            Whether the dispersion trend curve is being fitted as part of the VST
-            pipeline. (default: ``False``).
+        vst
+            Whether the dispersion trend curve is being fitted as part of the VST pipeline. (default: ``False``).
         """
         disp_param_name = "vst_genewise_dispersions" if vst else "genewise_dispersions"
 
@@ -1507,12 +1421,10 @@ class DeseqDataSet(ad.AnnData):
 
         Parameters
         ----------
-        niter : int
+        niter
             Maximum number of iterations to perform (default: ``10``).
-
-        quant : float
-            Quantile value at which negative likelihood is cut in the optimization
-            (default: ``0.95``).
+        quant
+            Quantile value at which negative likelihood is cut in the optimization (default: ``0.95``).
 
         """
         # Initialize size factors and normed counts fields

--- a/src/pydeseq2/default_inference.py
+++ b/src/pydeseq2/default_inference.py
@@ -21,21 +21,20 @@ from pydeseq2.misc import get_num_processes
 class DefaultInference(inference.Inference):
     """Default DESeq2-related inference methods, using scipy/sklearn/numpy.
 
-    This object contains the interface to the default inference routines and uses
-    joblib internally for parallelization. Inherit this class or its parent to write
-    custom inference routines.
+    This object contains the interface to the default inference routines and uses joblib internally for parallelization.
+    Inherit this class or its parent to write custom inference routines.
 
     Parameters
     ----------
-    joblib_verbosity : int
-        The verbosity level for joblib tasks. The higher the value, the more updates
-        are reported. (default: ``0``).
-    batch_size : int
+    joblib_verbosity
+        The verbosity level for joblib tasks.
+        The higher the value, the more updates are reported. (default: ``0``).
+    batch_size
         Number of tasks to allocate to each joblib parallel worker. (default: ``128``).
-    n_cpus : int
-        Number of cpus to use. If None, all available cpus will be used.
-        (default: ``None``).
-    backend : str
+    n_cpus
+        Number of cpus to use.
+        If None, all available cpus will be used. (default: ``None``).
+    backend
         Joblib backend.
     """
 

--- a/src/pydeseq2/dispersions.py
+++ b/src/pydeseq2/dispersions.py
@@ -25,16 +25,14 @@ def dispersion_trend(
 
     Parameters
     ----------
-    normed_mean : float or ndarray
+    normed_mean
         Mean of normalized counts for a given gene or set of genes.
-
-    coeffs : ndarray or pd.Series
+    coeffs
         Fitted dispersion trend coefficients :math:`a_0` and :math:`a_1`.
 
     Returns
     -------
-    float or ndarray
-        Dispersion trend :math:`a_1/ \mu + a_0`.
+    Dispersion trend :math:`a_1/ \mu + a_0`.
     """
     if isinstance(coeffs, pd.Series):
         return coeffs["a0"] + coeffs["a1"] / normed_mean
@@ -45,22 +43,19 @@ def dispersion_trend(
 def trimmed_cell_variance(counts: np.ndarray, cells: pd.Series) -> np.ndarray:
     """Return trimmed variance of counts according to condition.
 
-    Compute the variance after trimming data of its smallest and largest elements,
-    grouped by cohorts, and return the max across cohorts.
+    Compute the variance after trimming data of its smallest and largest elements, grouped by cohorts, and return the max across cohorts.
     The trim factor is a function of data size.
 
     Parameters
     ----------
-    counts : ndarray
+    counts
         Sample-wise gene counts.
-
-    cells : pandas.Series
+    cells
         Cohort affiliation of each sample.
 
     Returns
     -------
-    ndarray :
-        Gene-wise trimmed variance estimate.
+    Gene-wise trimmed variance estimate.
     """
     # how much to trim at different n
     trimratio = (1 / 3, 1 / 4, 1 / 8)
@@ -102,19 +97,16 @@ def trimmed_variance(
 
     Parameters
     ----------
-    features : ndarray
+    features
         Data whose trimmed variance to compute.
-
-    trim : float
+    trim
         Fraction of data to trim at each end. (default: ``0.125``).
-
-    axis : int
+    axis
         Dimension along which to compute variance. (default: ``0``).
 
     Returns
     -------
-    float or ndarray
-        Trimmed variances.
+    Trimmed variances.
     """
     rm = trimmed_mean(x, trim=trim, axis=axis)
     sqerror = (x - rm) ** 2
@@ -136,49 +128,38 @@ def fit_alpha_mle(
 ) -> tuple[float, bool]:
     """Estimate the dispersion parameter of a negative binomial GLM.
 
-    Note: it is possible to pass counts, design_matrix and mu arguments in the form of
-    pandas Series, but using numpy arrays makes the code significantly faster.
+    Note: it is possible to pass counts, design_matrix and mu arguments in the form of pandas Series, but using numpy arrays makes the code significantly faster.
 
     Parameters
     ----------
-    counts : ndarray
+    counts
         Raw counts for a given gene.
-
-    design_matrix : ndarray
+    design_matrix
         Design matrix.
-
-    mu : ndarray
+    mu
         Mean estimation for the NB model.
-
-    alpha_hat : float
+    alpha_hat
         Initial dispersion estimate.
-
-    min_disp : float
+    min_disp
         Lower threshold for dispersion parameters.
-
-    max_disp : float
+    max_disp
         Upper threshold for dispersion parameters.
-
-    prior_disp_var : float
+    prior_disp_var
         Prior dispersion variance.
-
-    cr_reg : bool
+    cr_reg
         Whether to use Cox-Reid regularization. (default: ``True``).
-
-    prior_reg : bool
+    prior_reg
         Whether to use prior log-residual regularization. (default: ``False``).
-
-    optimizer : str
-        Optimizing method to use. Accepted values: 'BFGS' or 'L-BFGS-B'.
-        (default: ``'L-BFGS-B'``).
+    optimizer
+        Optimizing method to use.
+        Accepted values: 'BFGS' or 'L-BFGS-B'. (default: ``'L-BFGS-B'``).
 
     Returns
     -------
-    float
-        Dispersion estimate.
+    Dispersion estimate.
 
-    bool
-        Whether L-BFGS-B converged. If not, dispersion is estimated using grid search.
+    Whether L-BFGS-B converged.
+    If not, dispersion is estimated using grid search.
     """
     assert optimizer in ["BFGS", "L-BFGS-B"]
 
@@ -253,22 +234,21 @@ def fit_rough_dispersions(
 ) -> np.ndarray:
     """Rough dispersion estimates from linear model, as per the R code.
 
-    Used as initial estimates in :meth:`DeseqDataSet.fit_genewise_dispersions()
-    <pydeseq2.dds.DeseqDataSet.fit_genewise_dispersions>`.
+    Used as initial estimates in :meth:`DeseqDataSet.fit_genewise_dispersions() <pydeseq2.dds.DeseqDataSet.fit_genewise_dispersions>`.
 
     Parameters
     ----------
-    normed_counts : ndarray
-        Array of deseq2-normalized read counts. Rows: samples, columns: genes.
-
-    design_matrix : pandas.DataFrame
+    normed_counts
+        Array of deseq2-normalized read counts.
+        Rows: samples, columns: genes.
+    design_matrix
         A DataFrame with experiment design information (to split cohorts).
-        Indexed by sample barcodes. Unexpanded, *with* intercept.
+        Indexed by sample barcodes.
+        Unexpanded, *with* intercept.
 
     Returns
     -------
-    ndarray
-        Estimated dispersion parameter for each gene.
+    Estimated dispersion parameter for each gene.
     """
     num_samples, num_vars = design_matrix.shape
     # This method is only possible when num_samples > num_vars.
@@ -295,21 +275,19 @@ def fit_moments_dispersions(
 ) -> np.ndarray:
     """Dispersion estimates based on moments, as per the R code.
 
-    Used as initial estimates in :meth:`DeseqDataSet.fit_genewise_dispersions()
-    <pydeseq2.dds.DeseqDataSet.fit_genewise_dispersions>`.
+    Used as initial estimates in :meth:`DeseqDataSet.fit_genewise_dispersions() <pydeseq2.dds.DeseqDataSet.fit_genewise_dispersions>`.
 
     Parameters
     ----------
-    normed_counts : ndarray
-        Array of deseq2-normalized read counts. Rows: samples, columns: genes.
-
-    size_factors : ndarray
+    normed_counts
+        Array of deseq2-normalized read counts.
+        Rows: samples, columns: genes.
+    size_factors
         DESeq2 normalization factors.
 
     Returns
     -------
-    ndarray
-        Estimated dispersion parameter for each gene.
+    Estimated dispersion parameter for each gene.
     """
     # Exclude genes with all zeroes
     normed_counts = normed_counts[:, ~(normed_counts == 0).all(axis=0)]
@@ -331,18 +309,18 @@ def robust_method_of_moments_disp(
 
     Parameters
     ----------
-    normed_counts : ndarray
-        Array of deseq2-normalized read counts. Rows: samples, columns: genes.
-
-    design_matrix : pandas.DataFrame
+    normed_counts
+        Array of deseq2-normalized read counts.
+        Rows: samples, columns: genes.
+    design_matrix
         A DataFrame with experiment design information (to split cohorts).
-        Indexed by sample barcodes. Unexpanded, *with* intercept.
+        Indexed by sample barcodes.
+        Unexpanded, *with* intercept.
 
     Returns
     -------
-    ndarray
-        Trimmed method of moment dispersion estimates.
-        Used for outlier detection based on Cook's distance.
+    Trimmed method of moment dispersion estimates.
+    Used for outlier detection based on Cook's distance.
     """
     # if there are 3 or more replicates in any cell
     three_or_more = n_or_more_replicates(design_matrix, 3)

--- a/src/pydeseq2/distributions.py
+++ b/src/pydeseq2/distributions.py
@@ -13,9 +13,7 @@ def nb_nll(
 ) -> float | np.ndarray:
     r"""Neg log-likelihood of a negative binomial of parameters ``mu`` and ``alpha``.
 
-    Mathematically, if ``counts`` is a vector of counting entries :math:`y_i`
-    then the likelihood of each entry :math:`y_i` to be drawn from a negative
-    binomial :math:`NB(\mu, \alpha)` is [1]
+    Mathematically, if ``counts`` is a vector of counting entries :math:`y_i` then the likelihood of each entry :math:`y_i` to be drawn from a negative binomial :math:`NB(\mu, \alpha)` is [1]
 
     .. math::
         p(y_i | \mu, \alpha) = \frac{\Gamma(y_i + \alpha^{-1})}{
@@ -24,8 +22,7 @@ def nb_nll(
         \left(\frac{1}{1 + \alpha \mu} \right)^{1/\alpha}
         \left(\frac{\mu}{\alpha^{-1} + \mu} \right)^{y_i}
 
-    As a consequence, assuming there are :math:`n` entries,
-    the total negative log-likelihood for ``counts`` is
+    As a consequence, assuming there are :math:`n` entries, the total negative log-likelihood for ``counts`` is
 
     .. math::
         \ell(\mu, \alpha) = \frac{n}{\alpha} \log(\alpha) +
@@ -41,21 +38,16 @@ def nb_nll(
 
     Parameters
     ----------
-    counts : ndarray
+    counts
         Observations.
-
-    mu : ndarray
+    mu
         Mean of the distribution :math:`\mu`.
-
-    alpha : float or ndarray
-        Dispersion of the distribution :math:`\alpha`,
-        s.t. the variance is :math:`\mu + \alpha \mu^2`.
+    alpha
+        Dispersion of the distribution :math:`\alpha`, s.t. the variance is :math:`\mu + \alpha \mu^2`.
 
     Returns
     -------
-    float or ndarray
-        Negative log likelihood of the observations counts
-        following :math:`NB(\mu, \alpha)`.
+    Negative log likelihood of the observations counts following :math:`NB(\mu, \alpha)`.
 
     Notes
     -----
@@ -89,20 +81,16 @@ def dnb_nll(counts: np.ndarray, mu: np.ndarray, alpha: float) -> float:
 
     Parameters
     ----------
-    counts : ndarray
+    counts
         Observations.
-
-    mu : float
+    mu
         Mean of the distribution.
-
-    alpha : float
-        Dispersion of the distribution,
-        s.t. the variance is :math:`\mu + \alpha\mu^2`.
+    alpha
+        Dispersion of the distribution, s.t. the variance is :math:`\mu + \alpha\mu^2`.
 
     Returns
     -------
-    float
-        Derivative of negative log likelihood of NB w.r.t. :math:`\alpha`.
+    Derivative of negative log likelihood of NB w.r.t. :math:`\alpha`.
     """
     alpha_neg1 = 1 / alpha
     ll_part = (
@@ -134,34 +122,26 @@ def nbinomFn(
 
     Parameters
     ----------
-    beta : ndarray
+    beta
         2-element array: intercept and LFC coefficients.
-
-    design_matrix : ndarray
+    design_matrix
         Design matrix.
-
-    counts : ndarray
+    counts
         Raw counts.
-
-    size : ndarray
+    size
         Size parameter of NB family (inverse of dispersion).
-
-    offset : ndarray
+    offset
         Natural logarithm of size factor.
-
-    prior_no_shrink_scale : float
+    prior_no_shrink_scale
         Prior variance for the intercept.
-
-    prior_scale : float
+    prior_scale
         Prior variance for the intercept.
-
-    shrink_index : int
+    shrink_index
         Index of the LFC coordinate to shrink. (default: ``1``).
 
     Returns
     -------
-    float
-        Sum of the NB negative likelihood and apeGLM prior.
+    Sum of the NB negative likelihood and apeGLM prior.
     """
     num_vars = design_matrix.shape[-1]
 
@@ -197,40 +177,31 @@ def nbinomGLM(
 
     Parameters
     ----------
-    design_matrix : ndarray
+    design_matrix
         Design matrix.
-
-    counts : ndarray
+    counts
         Raw counts.
-
-    size : ndarray
+    size
         Size parameter of NB family (inverse of dispersion).
-
-    offset : ndarray
+    offset
         Natural logarithm of size factor.
-
-    prior_no_shrink_scale : float
+    prior_no_shrink_scale
         Prior variance for the intercept.
-
-    prior_scale : float
+    prior_scale
         Prior variance for the LFC parameter.
-
-    optimizer : str
+    optimizer
         Optimizing method to use in case IRLS starts diverging.
         Accepted values: 'L-BFGS-B', 'BFGS' or 'Newton-CG'. (default: ``'Newton-CG'``).
-
-    shrink_index : int
+    shrink_index
         Index of the LFC coordinate to shrink. (default: ``1``).
 
     Returns
     -------
-    beta: ndarray
+    beta
         2-element array, containing the intercept (first) and the LFC (second).
-
-    inv_hessian: ndarray
+    inv_hessian
         Inverse of the Hessian of the objective at the estimated MAP LFC.
-
-    converged: bool
+    converged
         Whether L-BFGS-B converged.
     """
     num_vars = design_matrix.shape[-1]

--- a/src/pydeseq2/ds.py
+++ b/src/pydeseq2/ds.py
@@ -19,107 +19,73 @@ from pydeseq2.stats import lowess
 class DeseqStats:
     """PyDESeq2 statistical tests for differential expression.
 
-    Implements p-value estimation for differential gene expression according
-    to the DESeq2 pipeline :cite:p:`DeseqStats-love2014moderated`.
+    Implements p-value estimation for differential gene expression according to the DESeq2 pipeline :cite:p:`DeseqStats-love2014moderated`.
 
     Also supports apeGLM log-fold change shrinkage :cite:p:`DeseqStats-zhu2019heavy`.
 
     Parameters
     ----------
-    dds : DeseqDataSet
+    dds
         DeseqDataSet for which dispersion and LFCs were already estimated.
-
-    contrast : list or ndarray
+    contrast
         Either a list of three strings or a numpy array.
-        If a list of three strings, it must be in the following format:
-        ``['variable_of_interest', 'tested_level', 'ref_level']``.
+        If a list of three strings, it must be in the following format: ``['variable_of_interest', 'tested_level', 'ref_level']``.
         Names must correspond to the metadata data passed to the DeseqDataSet.
-        E.g., ``['condition', 'B', 'A']`` will measure the LFC of 'condition B' compared
-        to 'condition A'.
-        If a numpy array, it must be a contrast vector of the same length as the design
-        matrix.
-
-    alpha : float
-        P-value and adjusted p-value significance threshold (usually 0.05).
-        (default: ``0.05``).
-
-    cooks_filter : bool
+        E.g., ``['condition', 'B', 'A']`` will measure the LFC of 'condition B' compared to 'condition A'.
+        If a numpy array, it must be a contrast vector of the same length as the design matrix.
+    alpha
+        P-value and adjusted p-value significance threshold (usually 0.05). (default: ``0.05``).
+    cooks_filter
         Whether to filter p-values based on cooks outliers. (default: ``True``).
-
-    independent_filter : bool
-        Whether to perform independent filtering to correct p-value trends.
-        (default: ``True``).
-
-    prior_LFC_var : ndarray
+    independent_filter
+        Whether to perform independent filtering to correct p-value trends. (default: ``True``).
+    prior_LFC_var
         Prior variance for LFCs, used for ridge regularization. (default: ``None``).
-
-    lfc_null : float
+    lfc_null
         The (log2) log fold change under the null hypothesis. (default: ``0``).
-
-    alt_hypothesis : str, optional
-        The alternative hypothesis for computing wald p-values. By default, the normal
-        Wald test assesses deviation of the estimated log fold change from the null
-        hypothesis, as given by ``lfc_null``.
+    alt_hypothesis
+        The alternative hypothesis for computing wald p-values.
+        By default, the normal Wald test assesses deviation of the estimated log fold change from the null hypothesis, as given by ``lfc_null``.
         One of ``["greaterAbs", "lessAbs", "greater", "less"]`` or ``None``.
-        The alternative hypothesis corresponds to what the user wants to find rather
-        than the null hypothesis. (default: ``None``).
-
-    inference : Inference
-        Implementation of inference routines object instance.
-        (default:
-        :class:`DefaultInference <pydeseq2.default_inference.DefaultInference>`).
-
-    quiet : bool
+        The alternative hypothesis corresponds to what the user wants to find rather than the null hypothesis. (default: ``None``).
+    inference
+        Implementation of inference routines object instance. (default: :class:`DefaultInference <pydeseq2.default_inference.DefaultInference>`).
+    quiet
         Suppress deseq2 status updates during fit.
 
     Attributes
     ----------
-    base_mean : pandas.Series
+    base_mean
         Genewise means of normalized counts.
-
-    lfc_null : float
+    lfc_null
         The (log2) log fold change under the null hypothesis.
-
-    alt_hypothesis : str, optional
+    alt_hypothesis
         The alternative hypothesis for computing wald p-values.
-
-    contrast_vector : ndarray
+    contrast_vector
         Vector encoding the contrast (variable being tested).
-
-    contrast_idx : int
+    contrast_idx
         Index of the LFC column corresponding to the variable being tested.
-
-    design_matrix : pandas.DataFrame
+    design_matrix
         A DataFrame with experiment design information (to split cohorts).
-        Indexed by sample barcodes. Depending on the contrast that is provided to the
-        DeseqStats object, it may differ from the DeseqDataSet design matrix, as the
-        reference level may need to be adapted.
-
-    LFC : pandas.DataFrame
+        Indexed by sample barcodes.
+        Depending on the contrast that is provided to the DeseqStats object, it may differ from the DeseqDataSet design matrix, as the reference level may need to be adapted.
+    LFC
         Estimated log-fold change between conditions and intercept, in natural log scale.
-
-    SE : pandas.Series
+    SE
         Standard LFC error.
-
-    statistics : pandas.Series
+    statistics
         Wald statistics.
-
-    p_values : pandas.Series
+    p_values
         P-values estimated from Wald statistics.
-
-    padj : pandas.Series
+    padj
         P-values adjusted for multiple testing.
-
-    results_df : pandas.DataFrame
+    results_df
         Summary of the statistical analysis.
-
-    shrunk_LFCs : bool
+    shrunk_LFCs
         Whether LFCs are shrunk.
-
-    n_processes : int
+    n_processes
         Number of threads to use for multiprocessing.
-
-    quiet : bool
+    quiet
         Suppress deseq2 status updates during fit.
 
     References
@@ -231,8 +197,7 @@ class DeseqStats:
         Parameters
         ----------
         **kwargs
-            Keyword arguments: providing new values for ``lfc_null`` or
-            ``alt_hypothesis`` will override the corresponding ``DeseqStat`` attributes.
+            Keyword arguments: providing new values for ``lfc_null`` or ``alt_hypothesis`` will override the corresponding ``DeseqStat`` attributes.
         """
         new_lfc_null = kwargs.get("lfc_null", "default")
         new_alt_hypothesis = kwargs.get("alt_hypothesis", "default")
@@ -367,13 +332,12 @@ class DeseqStats:
 
         Parameters
         ----------
-        coeff : str
-            The LFC coefficient to shrink. Must be one of the columns of the LFC matrix.
-            (default: ``None``).
-
-        adapt: bool
-            Whether to use the MLE estimates of LFC to adapt the prior. If False, the
-            prior scale is set to 1. (``default=True``)
+        coeff
+            The LFC coefficient to shrink.
+            Must be one of the columns of the LFC matrix. (default: ``None``).
+        adapt
+            Whether to use the MLE estimates of LFC to adapt the prior.
+            If False, the prior scale is set to 1. (``default=True``)
         """
         if coeff not in self.LFC.columns:
             raise KeyError(
@@ -454,19 +418,16 @@ class DeseqStats:
         """
         Create an log ratio (M)-average (A) plot using matplotlib.
 
-        Useful for looking at log fold-change versus mean expression
-        between two groups/samples/etc.
+        Useful for looking at log fold-change versus mean expression between two groups/samples/etc.
         Uses matplotlib to emulate the ``make_MA()`` function in DESeq2 in R.
 
         Parameters
         ----------
-        log : bool
+        log
             Whether or not to log scale x and y axes (``default=True``).
-
-        save_path : str, optional
-            The path where to save the plot. If left None, the plot won't be saved
-            (``default=None``).
-
+        save_path
+            The path where to save the plot.
+            If left None, the plot won't be saved (``default=None``).
         **kwargs
             Matplotlib keyword arguments for the scatter plot.
         """
@@ -562,19 +523,16 @@ class DeseqStats:
 
         Parameters
         ----------
-        coeff_idx : str
+        coeff_idx
             Index of the coefficient to shrink.
-
-        min_var : float
+        min_var
             Lower bound for prior variance. (default: ``1e-6``).
-
-        max_var : float
+        max_var
             Upper bound for prior variance. (default: ``400``).
 
         Returns
         -------
-        float
-            Estimated prior variance.
+        Estimated prior variance.
         """
         keep = ~self.LFC.iloc[:, coeff_idx].isna()
         S = self.LFC[keep].iloc[:, coeff_idx] ** 2

--- a/src/pydeseq2/glm.py
+++ b/src/pydeseq2/glm.py
@@ -31,57 +31,40 @@ def irls_solver(
 
     Parameters
     ----------
-    counts : ndarray
+    counts
         Raw counts for a given gene.
-
-    size_factors : ndarray
+    size_factors
         Sample-wise scaling factors (obtained from median-of-ratios).
-
-    design_matrix : ndarray
+    design_matrix
         Design matrix.
-
-    disp : float
+    disp
         Gene-wise dispersion prior.
-
-    min_mu : float
-        Lower bound on estimated means, to ensure numerical stability.
-        (default: ``0.5``).
-
-    beta_tol : float
-        Stopping criterion for IRWLS:
-        :math:`\vert dev - dev_{old}\vert / \vert dev + 0.1 \vert < \beta_{tol}`.
-        (default: ``1e-8``).
-
-    min_beta : float
+    min_mu
+        Lower bound on estimated means, to ensure numerical stability. (default: ``0.5``).
+    beta_tol
+        Stopping criterion for IRWLS: :math:`\vert dev - dev_{old}\vert / \vert dev + 0.1 \vert < \beta_{tol}`. (default: ``1e-8``).
+    min_beta
         Lower-bound on LFC. (default: ``-30``).
-
-    max_beta : float
+    max_beta
         Upper-bound on LFC. (default: ``-30``).
-
-    optimizer : str
+    optimizer
         Optimizing method to use in case IRLS starts diverging.
         Accepted values: 'BFGS' or 'L-BFGS-B'.
-        NB: only 'L-BFGS-B' ensures that LFCS will
-        lay in the [min_beta, max_beta] range. (default: ``'L-BFGS-B'``).
-
-    maxiter : int
-        Maximum number of IRLS iterations to perform before switching to L-BFGS-B.
-        (default: ``250``).
+        NB: only 'L-BFGS-B' ensures that LFCS will lay in the [min_beta, max_beta] range. (default: ``'L-BFGS-B'``).
+    maxiter
+        Maximum number of IRLS iterations to perform before switching to L-BFGS-B. (default: ``250``).
 
     Returns
     -------
-    beta: ndarray
+    beta
         Fitted (basemean, lfc) coefficients of negative binomial GLM.
-
-    mu: ndarray
+    mu
         Means estimated from size factors and beta: :math:`\mu = s_{ij} \exp(\beta^t X)`.
-
-    H: ndarray
+    H
         Diagonal of the :math:`W^{1/2} X (X^t W X)^-1 X^t W^{1/2}` covariance matrix.
-
-    converged: bool
-        Whether IRLS or the optimizer converged. If not and if dimension allows it,
-        perform grid search.
+    converged
+        Whether IRLS or the optimizer converged.
+        If not and if dimension allows it, perform grid search.
     """
     assert optimizer in ["BFGS", "L-BFGS-B"]
 
@@ -193,22 +176,18 @@ def fit_lin_mu(
 
     Parameters
     ----------
-    counts : ndarray
+    counts
         Raw counts for a given gene.
-
-    size_factors : ndarray
+    size_factors
         Sample-wise scaling factors (obtained from median-of-ratios).
-
-    design_matrix : ndarray
+    design_matrix
         Design matrix.
-
-    min_mu : float
+    min_mu
         Lower threshold for fitted means, for numerical stability. (default: ``0.5``).
 
     Returns
     -------
-    ndarray
-        Estimated mean.
+    Estimated mean.
     """
     reg = LinearRegression(fit_intercept=False)
     reg.fit(design_matrix, counts / size_factors)
@@ -229,44 +208,34 @@ def wald_test(
 ) -> tuple[float, float, float]:
     """Run Wald test for differential expression.
 
-    Computes Wald statistics, standard error and p-values from
-    dispersion and LFC estimates.
+    Computes Wald statistics, standard error and p-values from dispersion and LFC estimates.
 
     Parameters
     ----------
-    design_matrix : ndarray
+    design_matrix
         Design matrix.
-
-    disp : float
+    disp
         Dispersion estimate.
-
-    lfc : ndarray
+    lfc
         Log-fold change estimate (in natural log scale).
-
-    mu : ndarray
+    mu
         Mean estimation for the NB model.
-
-    ridge_factor : ndarray
+    ridge_factor
         Regularization factors.
-
-    contrast : ndarray
+    contrast
         Vector encoding the contrast that is being tested.
-
-    lfc_null : float
+    lfc_null
         The (log2) log fold change under the null hypothesis.
-
-    alt_hypothesis : str, optional
+    alt_hypothesis
         The alternative hypothesis for computing wald p-values.
 
     Returns
     -------
-    wald_p_value : float
+    wald_p_value
         Estimated p-value.
-
-    wald_statistic : float
+    wald_statistic
         Wald statistic.
-
-    wald_se : float
+    wald_se
         Standard error of the Wald statistic.
     """
     # Build covariance matrix estimator

--- a/src/pydeseq2/grid_search.py
+++ b/src/pydeseq2/grid_search.py
@@ -13,21 +13,16 @@ def vec_nb_nll(
 
     Parameters
     ----------
-    counts : ndarray
+    counts
         Observations.
-
-    mu : ndarray
+    mu
         Mean of the distribution.
-
-    alpha : ndarray or float
-        Dispersion of the distribution, s.t. the variance is
-        :math:`\mu + \alpha \mu^2`.
+    alpha
+        Dispersion of the distribution, s.t. the variance is :math:`\mu + \alpha \mu^2`.
 
     Returns
     -------
-    ndarray
-        Negative log likelihood of the observations counts following
-        :math:`NB(\mu, \alpha)`.
+    Negative log likelihood of the observations counts following :math:`NB(\mu, \alpha)`.
     """
     n = len(counts)
     alpha_neg1 = 1 / alpha
@@ -69,40 +64,30 @@ def grid_fit_alpha(
 
     Parameters
     ----------
-    counts : ndarray
+    counts
         Raw counts for a given gene.
-
-    design_matrix : ndarray
+    design_matrix
         Design matrix.
-
-    mu : ndarray
+    mu
         Mean estimation for the NB model.
-
-    alpha_hat : float
+    alpha_hat
         Initial dispersion estimate.
-
-    min_disp : float
+    min_disp
         Lower threshold for dispersion parameters.
-
-    max_disp : float
+    max_disp
         Upper threshold for dispersion parameters.
-
-    prior_disp_var : float, optional
+    prior_disp_var
         Prior dispersion variance.
-
-    cr_reg : bool
+    cr_reg
         Whether to use Cox-Reid regularization. (default: ``True``).
-
-    prior_reg : bool
+    prior_reg
         Whether to use prior log-residual regularization. (default: ``False``).
-
-    grid_length : int
+    grid_length
         Number of grid points. (default: ``100``).
 
     Returns
     -------
-    float
-        Logarithm of the fitted dispersion parameter.
+    Logarithm of the fitted dispersion parameter.
     """
     min_log_alpha = np.log(min_disp)
     max_log_alpha = np.log(max_disp)
@@ -154,39 +139,30 @@ def grid_fit_beta(
 ) -> np.ndarray:
     """Find best LFC parameter.
 
-    Perform 2D grid search to maximize negative binomial
-    GLM log-likelihood w.r.t. LFCs.
+    Perform 2D grid search to maximize negative binomial GLM log-likelihood w.r.t. LFCs.
 
     Parameters
     ----------
-    counts : ndarray
+    counts
         Raw counts for a given gene.
-
-    size_factors : ndarray
+    size_factors
         DESeq2 normalization factors.
-
-    design_matrix : ndarray
+    design_matrix
         Design matrix.
-
-    disp : float
+    disp
         Gene-wise dispersion prior.
-
-    min_mu : float
+    min_mu
         Lower threshold for dispersion parameters.
-
-    grid_length : int
+    grid_length
         Number of grid points. (default: ``100``).
-
-    min_beta : float
+    min_beta
         Lower-bound on LFC. (default: ``30``).
-
-    max_beta : float
+    max_beta
         Upper-bound on LFC. (default: ``30``).
 
     Returns
     -------
-    ndarray
-        Fitted LFC parameter.
+    Fitted LFC parameter.
     """
     x_grid = np.linspace(min_beta, max_beta, grid_length)
     y_grid = np.linspace(min_beta, max_beta, grid_length)
@@ -235,45 +211,34 @@ def grid_fit_shrink_beta(
 ) -> np.ndarray:
     """Find best LFC parameter.
 
-    Performs 2D grid search to maximize MAP negative binomial
-    GLM log-likelihood w.r.t. LFCs, with apeGLM prior.
+    Performs 2D grid search to maximize MAP negative binomial GLM log-likelihood w.r.t. LFCs, with apeGLM prior.
 
     Parameters
     ----------
-    counts : ndarray
+    counts
         Raw counts for a given gene.
-
-    offset : ndarray
+    offset
         Natural logarithm of size factor.
-
-    design_matrix : ndarray
+    design_matrix
         Design matrix.
-
-    size : ndarray
+    size
         Size parameter of NB family (inverse of dispersion).
-
-    prior_no_shrink_scale : float
+    prior_no_shrink_scale
         Prior variance for the intercept.
-
-    prior_scale : float
+    prior_scale
         Prior variance for the LFC coefficient.
-
-    scale_cnst : float
+    scale_cnst
         Scaling factor for the optimization.
-
-    grid_length : int
+    grid_length
         Number of grid points. (default: ``100``).
-
-    min_beta : int
+    min_beta
         Lower-bound on LFC. (default: ``30``).
-
-    max_beta : int
+    max_beta
         Upper-bound on LFC. (default: ``30``).
 
     Returns
     -------
-    ndarray
-        Fitted MAP LFC parameter.
+    Fitted MAP LFC parameter.
     """
     x_grid = np.linspace(min_beta, max_beta, grid_length)
     y_grid = np.linspace(min_beta, max_beta, grid_length)

--- a/src/pydeseq2/inference.py
+++ b/src/pydeseq2/inference.py
@@ -23,23 +23,18 @@ class Inference(ABC):
 
         Parameters
         ----------
-        counts : ndarray
+        counts
             Raw counts.
-
-        size_factors : ndarray
+        size_factors
             Sample-wise scaling factors (obtained from median-of-ratios).
-
-        design_matrix : ndarray
+        design_matrix
             Design matrix.
-
-        min_mu : float
-            Lower threshold for fitted means, for numerical stability.
-            (default: ``0.5``).
+        min_mu
+            Lower threshold for fitted means, for numerical stability. (default: ``0.5``).
 
         Returns
         -------
-        ndarray
-            Estimated mean.
+        Estimated mean.
         """
 
     @abstractmethod
@@ -62,59 +57,40 @@ class Inference(ABC):
 
         Parameters
         ----------
-        counts : ndarray
+        counts
             Raw counts.
-
-        size_factors : ndarray
+        size_factors
             Sample-wise scaling factors (obtained from median-of-ratios).
-
-        design_matrix : ndarray
+        design_matrix
             Design matrix.
-
-        disp : ndarray
+        disp
             Gene-wise dispersion prior.
-
-        min_mu : ndarray
-            Lower bound on estimated means, to ensure numerical stability.
-            (default: ``0.5``).
-
-        beta_tol : float
-            Stopping criterion for IRWLS:
-            :math:`\vert dev - dev_{old}\vert / \vert dev + 0.1 \vert < \beta_{tol}`.
-            (default: ``1e-8``).
-
-        min_beta : float
+        min_mu
+            Lower bound on estimated means, to ensure numerical stability. (default: ``0.5``).
+        beta_tol
+            Stopping criterion for IRWLS: :math:`\vert dev - dev_{old}\vert / \vert dev + 0.1 \vert < \beta_{tol}`. (default: ``1e-8``).
+        min_beta
             Lower-bound on LFC. (default: ``-30``).
-
-        max_beta : float
+        max_beta
             Upper-bound on LFC. (default: ``-30``).
-
-        optimizer : str
+        optimizer
             Optimizing method to use in case IRLS starts diverging.
             Accepted values: 'BFGS' or 'L-BFGS-B'.
-            NB: only 'L-BFGS-B' ensures that LFCS will
-            lay in the [min_beta, max_beta] range. (default: ``'L-BFGS-B'``).
-
-        maxiter : int
-            Maximum number of IRLS iterations to perform before switching to L-BFGS-B.
-            (default: ``250``).
+            NB: only 'L-BFGS-B' ensures that LFCS will lay in the [min_beta, max_beta] range. (default: ``'L-BFGS-B'``).
+        maxiter
+            Maximum number of IRLS iterations to perform before switching to L-BFGS-B. (default: ``250``).
 
         Returns
         -------
-        beta: ndarray
+        beta
             Fitted (basemean, lfc) coefficients of negative binomial GLM.
-
-        mu: ndarray
-            Means estimated from size factors and beta:
-            :math:`\mu = s_{ij} \exp(\beta^t X)`.
-
-        H: ndarray
-            Diagonal of the :math:`W^{1/2} X (X^t W X)^-1 X^t W^{1/2}`
-            covariance matrix.
-
-        converged: ndarray
-            Whether IRLS or the optimizer converged. If not and if dimension allows it,
-            perform grid search.
+        mu
+            Means estimated from size factors and beta: :math:`\mu = s_{ij} \exp(\beta^t X)`.
+        H
+            Diagonal of the :math:`W^{1/2} X (X^t W X)^-1 X^t W^{1/2}` covariance matrix.
+        converged
+            Whether IRLS or the optimizer converged.
+            If not and if dimension allows it, perform grid search.
         """
 
     @abstractmethod
@@ -135,45 +111,34 @@ class Inference(ABC):
 
         Parameters
         ----------
-        counts : ndarray
+        counts
             Raw counts.
-
-        design_matrix : ndarray
+        design_matrix
             Design matrix.
-
-        mu : ndarray
+        mu
             Mean estimation for the NB model.
-
-        alpha_hat : ndarray
+        alpha_hat
             Initial dispersion estimate.
-
-        min_disp : float
+        min_disp
             Lower threshold for dispersion parameters.
-
-        max_disp : float
+        max_disp
             Upper threshold for dispersion parameters.
-
-        prior_disp_var : float, optional
+        prior_disp_var
             Prior dispersion variance.
-
-        cr_reg : bool
+        cr_reg
             Whether to use Cox-Reid regularization. (default: ``True``).
-
-        prior_reg : bool
+        prior_reg
             Whether to use prior log-residual regularization. (default: ``False``).
-
-        optimizer : str
-            Optimizing method to use. Accepted values: 'BFGS' or 'L-BFGS-B'.
-            (default: ``'L-BFGS-B'``).
+        optimizer
+            Optimizing method to use.
+            Accepted values: 'BFGS' or 'L-BFGS-B'. (default: ``'L-BFGS-B'``).
 
         Returns
         -------
-        ndarray
-            Dispersion estimate.
+        Dispersion estimate.
 
-        ndarray
-            Whether L-BFGS-B converged. If not, dispersion is estimated
-            using grid search.
+        Whether L-BFGS-B converged.
+        If not, dispersion is estimated using grid search.
         """
 
     @abstractmethod
@@ -192,44 +157,34 @@ class Inference(ABC):
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Run Wald test for differential expression.
 
-        Computes Wald statistics, standard error and p-values from
-        dispersion and LFC estimates.
+        Computes Wald statistics, standard error and p-values from dispersion and LFC estimates.
 
         Parameters
         ----------
-        design_matrix : ndarray
+        design_matrix
             Design matrix.
-
-        disp : float
+        disp
             Dispersion estimate.
-
-        lfc : ndarray
+        lfc
             Log-fold change estimate (in natural log scale).
-
-        mu : float
+        mu
             Mean estimation for the NB model.
-
-        ridge_factor : ndarray
+        ridge_factor
             Regularization factors.
-
-        contrast : ndarray
+        contrast
             Vector encoding the contrast that is being tested.
-
-        lfc_null : float
+        lfc_null
             The (log2) log fold change under the null hypothesis.
-
-        alt_hypothesis : str or None
+        alt_hypothesis
             The alternative hypothesis for computing wald p-values.
 
         Returns
         -------
-        wald_p_value : ndarray
+        wald_p_value
             Estimated p-value.
-
-        wald_statistic : ndarray
+        wald_statistic
             Wald statistic.
-
-        wald_se : ndarray
+        wald_se
             Standard error of the Wald statistic.
         """
 
@@ -239,22 +194,21 @@ class Inference(ABC):
     ) -> np.ndarray:
         """'Rough dispersion' estimates from linear model, as per the R code.
 
-        Used as initial estimates in :meth:`DeseqDataSet.fit_genewise_dispersions()
-        <pydeseq2.dds.DeseqDataSet.fit_genewise_dispersions>`.
+        Used as initial estimates in :meth:`DeseqDataSet.fit_genewise_dispersions() <pydeseq2.dds.DeseqDataSet.fit_genewise_dispersions>`.
 
         Parameters
         ----------
-        normed_counts : ndarray
-            Array of deseq2-normalized read counts. Rows: samples, columns: genes.
-
-        design_matrix : pandas.DataFrame
+        normed_counts
+            Array of deseq2-normalized read counts.
+            Rows: samples, columns: genes.
+        design_matrix
             A DataFrame with experiment design information (to split cohorts).
-            Indexed by sample barcodes. Unexpanded, *with* intercept.
+            Indexed by sample barcodes.
+            Unexpanded, *with* intercept.
 
         Returns
         -------
-        ndarray
-            Estimated dispersion parameter for each gene.
+        Estimated dispersion parameter for each gene.
         """
 
     @abstractmethod
@@ -263,21 +217,19 @@ class Inference(ABC):
     ) -> np.ndarray:
         """Dispersion estimates based on moments, as per the R code.
 
-        Used as initial estimates in :meth:`DeseqDataSet.fit_genewise_dispersions()
-        <pydeseq2.dds.DeseqDataSet.fit_genewise_dispersions>`.
+        Used as initial estimates in :meth:`DeseqDataSet.fit_genewise_dispersions() <pydeseq2.dds.DeseqDataSet.fit_genewise_dispersions>`.
 
         Parameters
         ----------
-        normed_counts : ndarray
-            Array of deseq2-normalized read counts. Rows: samples, columns: genes.
-
-        size_factors : ndarray
+        normed_counts
+            Array of deseq2-normalized read counts.
+            Rows: samples, columns: genes.
+        size_factors
             DESeq2 normalization factors.
 
         Returns
         -------
-        ndarray
-            Estimated dispersion parameter for each gene.
+        Estimated dispersion parameter for each gene.
         """
 
     @abstractmethod
@@ -286,23 +238,22 @@ class Inference(ABC):
     ) -> tuple[np.ndarray, np.ndarray, bool]:
         """Fit a gamma glm on gene dispersions.
 
-        The intercept should be concatenated in this method
-        and the first returned coefficient should be the intercept.
+        The intercept should be concatenated in this method and the first returned coefficient should be the intercept.
 
         Parameters
         ----------
-        covariates : pd.Series
+        covariates
             Covariates for the regression (num_genes,).
-        targets : pd.Series
+        targets
             Targets for the regression (num_genes,).
 
         Returns
         -------
-        coeffs : ndarray
+        coeffs
             Coefficients of the regression.
-        predictions : ndarray
+        predictions
             Predictions of the regression.
-        converged : bool
+        converged
             Whether the optimization converged.
         """
 
@@ -324,39 +275,30 @@ class Inference(ABC):
 
         Parameters
         ----------
-        design_matrix : ndarray
+        design_matrix
             Design matrix.
-
-        counts : ndarray
+        counts
             Raw counts.
-
-        size : ndarray
+        size
             Size parameter of NB family (inverse of dispersion).
-
-        offset : ndarray
+        offset
             Natural logarithm of size factor.
-
-        prior_no_shrink_scale : float
+        prior_no_shrink_scale
             Prior variance for the intercept.
-
-        prior_scale : float
+        prior_scale
             Prior variance for the LFC parameter.
-
-        optimizer : str
+        optimizer
             Optimizing method to use in case IRLS starts diverging.
             Accepted values: 'L-BFGS-B', 'BFGS' or 'Newton-CG'.
-
-        shrink_index : int
+        shrink_index
             Index of the LFC coordinate to shrink. (default: ``1``).
 
         Returns
         -------
-        beta: ndarray
+        beta
             2-element array, containing the intercept (first) and the LFC (second).
-
-        inv_hessian: ndarray
+        inv_hessian
             Inverse of the Hessian of the objective at the estimated MAP LFC.
-
-        converged: ndarray
+        converged
             Whether L-BFGS-B converged for each optimization problem.
         """

--- a/src/pydeseq2/misc.py
+++ b/src/pydeseq2/misc.py
@@ -13,8 +13,9 @@ def test_valid_counts(counts: pd.DataFrame | np.ndarray) -> None:
 
     Parameters
     ----------
-    counts : pandas.DataFrame or ndarray
-        Raw counts. One column per gene, rows are indexed by sample barcodes.
+    counts
+        Raw counts.
+        One column per gene, rows are indexed by sample barcodes.
     """
     if isinstance(counts, pd.DataFrame):
         if counts.isna().any().any():
@@ -36,21 +37,18 @@ def n_or_more_replicates(design_matrix: pd.DataFrame, min_replicates: int) -> pd
     """
     Return a  series indicating whether samples have a minimum number of replicates.
 
-    Checks whether each sample has at least ``min_replicates`` replicates, based on its
-    combination of design factors.
+    Checks whether each sample has at least ``min_replicates`` replicates, based on its combination of design factors.
 
     Parameters
     ----------
-    design_matrix : pandas.DataFrame
+    design_matrix
         A DataFrame with experiment design information (to split cohorts).
-    min_replicates : int
+    min_replicates
         The minimum number of replicates to have to pass the threshold.
 
     Returns
     -------
-    pandas.Series
-        A boolean series indicating whether each sample has at least ``min_replicates``
-        replicates.
+    A boolean series indicating whether each sample has at least ``min_replicates`` replicates.
     """
     n_or_more = design_matrix.value_counts() >= min_replicates
     replaceable = n_or_more[pd.MultiIndex.from_frame(design_matrix)]
@@ -65,14 +63,13 @@ def get_num_processes(n_cpus: int | None) -> int:
 
     Parameters
     ----------
-    n_cpus : int, optional
-        Desired number of cpus. If ``None``, will return the number of available cpus.
-        (default: ``None``).
+    n_cpus
+        Desired number of cpus.
+        If ``None``, will return the number of available cpus. (default: ``None``).
 
     Returns
     -------
-    int
-        Number of processes to spawn.
+    Number of processes to spawn.
     """
     if n_cpus is None:
         try:

--- a/src/pydeseq2/plotting.py
+++ b/src/pydeseq2/plotting.py
@@ -22,22 +22,17 @@ def make_scatter(
 
     Parameters
     ----------
-    disps : list
+    disps
         List of ndarrays to plot.
-
-    legend_labels : list
+    legend_labels
         List of strings that correspond to plotted targets values for legend.
-
-    x_val : ndarray
+    x_val
         1D array to plot (example: ``dds.varm['_normed_means']``).
-
-    log : bool
+    log
         Whether or not to log scale features and targets axes (``default=True``).
-
-    save_path : str, optional
-        The path where to save the plot. If left None, the plot won't be saved
-        (``default=None``).
-
+    save_path
+        The path where to save the plot.
+        If left None, the plot won't be saved (``default=None``).
     **kwargs
         Matplotlib keyword arguments for the scatter plot.
     """
@@ -89,31 +84,24 @@ def make_MA_plot(
     """
     Create an log ratio (M)-average (A) plot using matplotlib.
 
-    Useful for looking at log fold-change versus mean expression
-    between two groups/samples/etc.
+    Useful for looking at log fold-change versus mean expression between two groups/samples/etc.
     Uses matplotlib to emulate the ``make_MA()`` function in DESeq2 in R.
 
     Parameters
     ----------
-    results_df : pd.DataFrame
+    results_df
         Resultant dataframe after running DeseqStats() and .summary().
-
-    padj_thresh : float
+    padj_thresh
         P-value threshold to subset scatterplot colors on.
-
-    log : bool
+    log
         Whether or not to log scale features and targets axes (``default=True``).
-
-    save_path : str, optional
-        The path where to save the plot. If left None, the plot won't be saved
-        (``default=None``).
-
-    lfc_null : float
+    save_path
+        The path where to save the plot.
+        If left None, the plot won't be saved (``default=None``).
+    lfc_null
         The (log2) log fold change under the null hypothesis. (default: ``0``).
-
-    alt_hypothesis : str, optional
+    alt_hypothesis
         The alternative hypothesis for computing wald p-values. (default: ``None``).
-
     **kwargs
         Matplotlib keyword arguments for the scatter plot.
     """

--- a/src/pydeseq2/preprocessing.py
+++ b/src/pydeseq2/preprocessing.py
@@ -11,16 +11,16 @@ def deseq2_norm(
 
     Parameters
     ----------
-    counts : pandas.DataFrame or ndarray
-            Raw counts. One column per gene, one row per sample.
+    counts
+        Raw counts.
+        One column per gene, one row per sample.
 
     Returns
     -------
-    deseq2_counts : pandas.DataFrame or ndarray
+    deseq2_counts
         DESeq2 normalized counts.
         One column per gene, rows are indexed by sample barcodes.
-
-    size_factors : pandas.DataFrame or ndarray
+    size_factors
         DESeq2 normalization factors.
     """
     logmeans, filtered_genes = deseq2_norm_fit(counts)
@@ -35,15 +35,15 @@ def deseq2_norm_fit(counts: pd.DataFrame | np.ndarray) -> tuple[np.ndarray, np.n
 
     Parameters
     ----------
-    counts : pandas.DataFrame or ndarray
-            Raw counts. One column per gene, one row per sample.
+    counts
+        Raw counts.
+        One column per gene, one row per sample.
 
     Returns
     -------
-    logmeans : ndarray
+    logmeans
         Gene-wise mean log counts.
-
-    filtered_genes : ndarray
+    filtered_genes
         Genes whose log means are different from -∞.
     """
     # Compute gene-wise mean log counts
@@ -63,27 +63,24 @@ def deseq2_norm_transform(
 ) -> tuple[pd.DataFrame | np.ndarray, pd.DataFrame | np.ndarray]:
     """Return normalized counts and size factors from the median of ratios method.
 
-    Can be applied on external dataset, using the ``logmeans`` and ``filtered_genes``
-    previously computed in the ``fit`` function.
+    Can be applied on external dataset, using the ``logmeans`` and ``filtered_genes`` previously computed in the ``fit`` function.
 
     Parameters
     ----------
-    counts : pandas.DataFrame or ndarray
-            Raw counts. One column per gene, one row per sample.
-
-    logmeans : ndarray
+    counts
+        Raw counts.
+        One column per gene, one row per sample.
+    logmeans
         Gene-wise mean log counts.
-
-    filtered_genes : ndarray
+    filtered_genes
         Genes whose log means are different from -∞.
 
     Returns
     -------
-    deseq2_counts : pandas.DataFrame or ndarray
+    deseq2_counts
         DESeq2 normalized counts.
         One column per gene, rows are indexed by sample barcodes.
-
-    size_factors : pandas.DataFrame or ndarray
+    size_factors
         DESeq2 normalization factors.
     """
     with np.errstate(divide="ignore"):  # ignore division by zero warnings

--- a/src/pydeseq2/stats.py
+++ b/src/pydeseq2/stats.py
@@ -14,19 +14,16 @@ def trimmed_mean(x: np.ndarray, trim: float = 0.1, **kwargs) -> float | np.ndarr
 
     Parameters
     ----------
-    x : ndarray
+    x
         Data whose mean to compute.
-
-    trim : float
+    trim
         Fraction of data to trim at each end. (default: ``0.1``).
-
     **kwargs
         Keyword arguments, useful to pass axis.
 
     Returns
     -------
-    float or ndarray :
-        Trimmed mean.
+    Trimmed mean.
     """
     assert trim <= 0.5
     if "axis" in kwargs:
@@ -50,13 +47,12 @@ def mean_absolute_deviation(x: np.ndarray) -> float:
 
     Parameters
     ----------
-    features : ndarray
+    features
         1D array whose MAD to compute.
 
     Returns
     -------
-    float
-        Mean absolute deviation estimator.
+    Mean absolute deviation estimator.
     """
     center = np.median(x)
     return np.median(np.abs(x - center)) / norm.ppf(0.75)
@@ -68,28 +64,27 @@ def lowess(
     """Run lowess smoothing: Robust locally weighted regression.
 
     The lowess function fits a nonparametric regression curve to a scatterplot.
-    The arrays features and targets contain an equal number of elements; each pair
-    (features[i], targets[i]) defines a data point in the scatterplot. The function
-    returns the estimated (smooth) values of targets.
-    The smoothing span is given by frac. A larger value for frac will result in a
-    smoother curve. The number of robustifying iterations is given by iter. The
-    function will run faster with a smaller number of iterations.
+    The arrays features and targets contain an equal number of elements; each pair (features[i], targets[i]) defines a data point in the scatterplot.
+    The function returns the estimated (smooth) values of targets.
+    The smoothing span is given by frac.
+    A larger value for frac will result in a smoother curve.
+    The number of robustifying iterations is given by iter.
+    The function will run faster with a smaller number of iterations.
 
     Parameters
     ----------
-    features : ndarray
+    features
         A 1D array of data points.
-    targets : ndarray
+    targets
         A 1D array of target values (with the same shape as features).
-    frac : float
+    frac
         The fraction of the data used when estimating each y-value. (default: ``2/3``).
-    iter : int
+    iter
         The number of robustifying iterations. (default: ``3``).
 
     Returns
     -------
-    ndarray
-        Estimated (smooth) values of targets.
+    Estimated (smooth) values of targets.
     """
     n = len(features)
     r = int(ceil(frac * n))

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -8,9 +8,7 @@ from pydeseq2.ds import DeseqStats
 
 
 def test_zero_genes():
-    """Test that genes with only 0 counts are handled by DeseqDataSet et DeseqStats,
-    and that NaNs are returned.
-    """
+    """Test that genes with only 0 counts are handled by DeseqDataSet et DeseqStats, and that NaNs are returned."""
 
     counts_df = load_example_data(
         modality="raw_counts",
@@ -65,9 +63,7 @@ def test_nan_counts():
 
 
 def test_numeric_counts():
-    """Test that a ValueError is thrown when the count matrix contains
-    non-numeric values.
-    """
+    """Test that a ValueError is thrown when the count matrix contains non-numeric values."""
     counts_df = pd.DataFrame(
         {"gene1": [0, "a"], "gene2": [4, 12]}, index=["sample1", "sample2"]
     )
@@ -78,8 +74,7 @@ def test_numeric_counts():
 
 
 def test_integer_counts():
-    """Test that a ValueError is thrown when the count matrix contains
-    non-integer values."""
+    """Test that a ValueError is thrown when the count matrix contains non-integer values."""
     counts_df = pd.DataFrame(
         {"gene1": [0, 1.5], "gene2": [4, 12]}, index=["sample1", "sample2"]
     )
@@ -90,8 +85,7 @@ def test_integer_counts():
 
 
 def test_non_negative_counts():
-    """Test that a ValueError is thrown when the count matrix contains
-    negative values."""
+    """Test that a ValueError is thrown when the count matrix contains negative values."""
     counts_df = pd.DataFrame(
         {"gene1": [0, -1], "gene2": [4, 12]}, index=["sample1", "sample2"]
     )
@@ -125,8 +119,7 @@ def test_one_factor():
 
 
 def test_rank_deficient_design():
-    """Test that a UserWarning is thrown when the design matrix does not have full
-    column rank."""
+    """Test that a UserWarning is thrown when the design matrix does not have full column rank."""
     counts_df = pd.DataFrame(
         {"gene1": [0, 1], "gene2": [4, 12]}, index=["sample1", "sample2"]
     )
@@ -139,8 +132,7 @@ def test_rank_deficient_design():
 
 
 def test_equal_num_vars_num_samples_design():
-    """Test that a ValueError is thrown when fitting dispersions if the design matrix
-    has equal numbers of rows and columns."""
+    """Test that a ValueError is thrown when fitting dispersions if the design matrix has equal numbers of rows and columns."""
     counts_df = pd.DataFrame(
         {"gene1": [0, 1, 55], "gene2": [4, 12, 60]},
         index=["sample1", "sample2", "sample3"],
@@ -162,8 +154,7 @@ def test_equal_num_vars_num_samples_design():
 
 
 def test_matching_samples():
-    """Test that a ValueError is thrown when the Index of the design matrix does not
-    match obs."""
+    """Test that a ValueError is thrown when the Index of the design matrix does not match obs."""
     counts_df = pd.DataFrame(
         {"gene1": [0, 1, 55], "gene2": [4, 12, 60]},
         index=["sample1", "sample2", "sample3"],
@@ -196,9 +187,7 @@ def test_matching_samples():
 
 
 def test_lfc_shrinkage_coeff():
-    """Test that a KeyError is thrown when attempting to shrink an unexisting LFC
-    coefficient.
-    """
+    """Test that a KeyError is thrown when attempting to shrink an unexisting LFC coefficient."""
 
     counts_df = load_example_data(
         modality="raw_counts",
@@ -225,8 +214,7 @@ def test_lfc_shrinkage_coeff():
 
 
 def test_indexes():
-    """Test that a ValueError is thrown when the count matrix and the metadata data
-    don't have the same index."""
+    """Test that a ValueError is thrown when the count matrix and the metadata data don't have the same index."""
     counts_df = pd.DataFrame(
         {"gene1": [0, 1], "gene2": [4, 12]}, index=["sample1", "sample2"]
     )
@@ -241,8 +229,7 @@ def test_indexes():
 
 
 def test_contrast():
-    """Test that KeyErrors/ValueErrors are thrown when invalid contrasts are passed to a
-    DeseqStats."""
+    """Test that KeyErrors/ValueErrors are thrown when invalid contrasts are passed to a DeseqStats."""
 
     counts_df = load_example_data(
         modality="raw_counts",
@@ -287,9 +274,7 @@ def test_contrast():
 
 
 def test_cooks_not_refitted():
-    """Test that an AttributeError is thrown when a `DeseqStats` object is initialized
-    from a `DeseqDataSet` whose `refit_cooks` attribute is set to True, but whose
-    Cooks outliers were not actually refitted."""
+    """Test that an AttributeError is thrown when a `DeseqStats` object is initialized from a `DeseqDataSet` whose `refit_cooks` attribute is set to True, but whose Cooks outliers were not actually refitted."""
 
     counts_df = load_example_data(
         modality="raw_counts",
@@ -365,8 +350,7 @@ def test_few_samples():
 
 
 def test_few_samples_and_outlier():
-    """Test that PyDESeq2 runs bug-free with outliers and a cohort with less than 3
-    samples.
+    """Test that PyDESeq2 runs bug-free with outliers and a cohort with less than 3 samples.
     TODO: refine this test to check the correctness of the output?
     """
 
@@ -496,8 +480,7 @@ def test_zero_inflated():
 
 def test_plot_MA():
     """
-    Test that a KeyError is thrown when attempting to run plot_MA without running the
-    statistical analysis first.
+    Test that a KeyError is thrown when attempting to run plot_MA without running the statistical analysis first.
     """
 
     counts_df = load_example_data(

--- a/tests/test_pydeseq2.py
+++ b/tests/test_pydeseq2.py
@@ -92,9 +92,7 @@ def test_size_factors_control_genes(counts_df, metadata):
 
 
 def test_deseq_independent_filtering_parametric_fit(counts_df, metadata, tol=0.02):
-    """Test that the outputs of the DESeq2 function match those of the original R
-    package, up to a tolerance in relative error.
-    """
+    """Test that the outputs of the DESeq2 function match those of the original R package, up to a tolerance in relative error."""
 
     test_path = str(Path(os.path.realpath(tests.__file__)).parent.resolve())
 
@@ -119,9 +117,7 @@ def test_deseq_independent_filtering_parametric_fit(counts_df, metadata, tol=0.0
 
 
 def test_deseq_independent_filtering_mean_fit(counts_df, metadata, tol=0.02):
-    """Test that the outputs of the DESeq2 function match those of the original R
-    package, up to a tolerance in relative error, with a mean fit.
-    """
+    """Test that the outputs of the DESeq2 function match those of the original R package, up to a tolerance in relative error, with a mean fit."""
 
     test_path = str(Path(os.path.realpath(tests.__file__)).parent.resolve())
 
@@ -148,10 +144,7 @@ def test_deseq_independent_filtering_mean_fit(counts_df, metadata, tol=0.02):
 def test_deseq_without_independent_filtering_parametric_fit(
     counts_df, metadata, tol=0.02
 ):
-    """Test that the outputs of the DESeq2 function match those of the original R
-    package, up to a tolerance in relative error, with a parametric fit and no
-    independent filtering.
-    """
+    """Test that the outputs of the DESeq2 function match those of the original R package, up to a tolerance in relative error, with a parametric fit and no independent filtering."""
 
     test_path = str(Path(os.path.realpath(tests.__file__)).parent.resolve())
 
@@ -179,9 +172,7 @@ def test_deseq_without_independent_filtering_parametric_fit(
 
 @pytest.mark.parametrize("alt_hypothesis", ["lessAbs", "greaterAbs", "less", "greater"])
 def test_alt_hypothesis(alt_hypothesis, counts_df, metadata, tol=0.02):
-    """Test that the outputs of the DESeq2 function match those of the original R
-    package, up to a tolerance in relative error, with the alternative hypothesis test.
-    """
+    """Test that the outputs of the DESeq2 function match those of the original R package, up to a tolerance in relative error, with the alternative hypothesis test."""
 
     test_path = str(Path(os.path.realpath(tests.__file__)).parent.resolve())
 
@@ -226,10 +217,8 @@ def test_alt_hypothesis(alt_hypothesis, counts_df, metadata, tol=0.02):
 
 
 def test_deseq_no_refit_cooks(counts_df, metadata, tol=0.02):
-    """Test that the outputs of the DESeq2 function *without cooks refit*
-    match those of the original R package, up to a tolerance in relative error.
-    Note: this is just to check that the workflow runs bug-free, as we expect no outliers
-    in the synthetic dataset.
+    """Test that the outputs of the DESeq2 function *without cooks refit* match those of the original R package, up to a tolerance in relative error.
+    Note: this is just to check that the workflow runs bug-free, as we expect no outliers in the synthetic dataset.
     """
 
     test_path = str(Path(os.path.realpath(tests.__file__)).parent.resolve())
@@ -254,9 +243,7 @@ def test_deseq_no_refit_cooks(counts_df, metadata, tol=0.02):
 
 
 def test_lfc_shrinkage(counts_df, metadata, tol=0.02):
-    """Test that the outputs of the lfc_shrink function match those of the original
-    R package (starting from the same inputs), up to a tolerance in relative error.
-    """
+    """Test that the outputs of the lfc_shrink function match those of the original R package (starting from the same inputs), up to a tolerance in relative error."""
 
     test_path = str(Path(os.path.realpath(tests.__file__)).parent.resolve())
     r_res = pd.read_csv(
@@ -297,9 +284,7 @@ def test_lfc_shrinkage(counts_df, metadata, tol=0.02):
 
 
 def test_lfc_shrinkage_no_apeAdapt(counts_df, metadata, tol=0.02):
-    """Test that the outputs of the lfc_shrink function match those of the original
-    R package (starting from the same inputs), up to a tolerance in relative error.
-    """
+    """Test that the outputs of the lfc_shrink function match those of the original R package (starting from the same inputs), up to a tolerance in relative error."""
 
     test_path = str(Path(os.path.realpath(tests.__file__)).parent.resolve())
     r_res = pd.read_csv(
@@ -342,10 +327,7 @@ def test_lfc_shrinkage_no_apeAdapt(counts_df, metadata, tol=0.02):
 
 
 def test_iterative_size_factors(counts_df, metadata, tol=0.02):
-    """Test that the outputs of the iterative size factor method match those of the
-    original R package (starting from the same inputs), up to a tolerance in relative
-    error.
-    """
+    """Test that the outputs of the iterative size factor method match those of the original R package (starting from the same inputs), up to a tolerance in relative error."""
 
     test_path = str(Path(os.path.realpath(tests.__file__)).parent.resolve())
 
@@ -365,10 +347,7 @@ def test_iterative_size_factors(counts_df, metadata, tol=0.02):
 
 
 def test_lfc_shrinkage_large_counts(counts_df, metadata, tol=0.02):
-    """Test that the outputs of the lfc_shrink function match those of the original
-    R package (starting from the same inputs), up to a tolerance in relative error in
-    the presence of a gene with very large counts.
-    """
+    """Test that the outputs of the lfc_shrink function match those of the original R package (starting from the same inputs), up to a tolerance in relative error in the presence of a gene with very large counts."""
 
     test_path = str(Path(os.path.realpath(tests.__file__)).parent.resolve())
     r_res = pd.read_csv(
@@ -433,9 +412,7 @@ def test_lfc_shrinkage_large_counts(counts_df, metadata, tol=0.02):
 # Multi-factor tests
 @pytest.mark.parametrize("with_outliers", [True, False])
 def test_multifactor_deseq(counts_df, metadata, with_outliers, tol=0.04):
-    """Test that the outputs of the DESeq2 function match those of the original R
-    package, up to a tolerance in relative error.
-    """
+    """Test that the outputs of the DESeq2 function match those of the original R package, up to a tolerance in relative error."""
 
     test_path = str(Path(os.path.realpath(tests.__file__)).parent.resolve())
 
@@ -468,9 +445,7 @@ def test_multifactor_deseq(counts_df, metadata, with_outliers, tol=0.04):
 
 
 def test_multifactor_lfc_shrinkage(counts_df, metadata, tol=0.02):
-    """Test that the outputs of the lfc_shrink function match those of the original
-    R package (starting from the same inputs), up to a tolerance in relative error.
-    """
+    """Test that the outputs of the lfc_shrink function match those of the original R package (starting from the same inputs), up to a tolerance in relative error."""
 
     test_path = str(Path(os.path.realpath(tests.__file__)).parent.resolve())
     r_res = pd.read_csv(
@@ -515,9 +490,7 @@ def test_continuous_deseq(
     with_outliers,
     tol=0.04,
 ):
-    """Test that the outputs of the DESeq2 function match those of the original R
-    package, up to a tolerance in relative error, with a continuous factor.
-    """
+    """Test that the outputs of the DESeq2 function match those of the original R package, up to a tolerance in relative error, with a continuous factor."""
 
     test_path = str(Path(os.path.realpath(tests.__file__)).parent.resolve())
 
@@ -564,9 +537,7 @@ def test_continuous_deseq(
 
 
 def test_continuous_lfc_shrinkage(tol=0.02):
-    """Test that the outputs of the lfc_shrink function match those of the original
-    R package (starting from the same inputs), up to a tolerance in relative error.
-    """
+    """Test that the outputs of the lfc_shrink function match those of the original R package (starting from the same inputs), up to a tolerance in relative error."""
 
     test_path = str(Path(os.path.realpath(tests.__file__)).parent.resolve())
 
@@ -627,10 +598,7 @@ def test_wide_deseq(
     low_memory,
     tol=0.02,
 ):
-    """Test that the outputs of the DESeq2 function match those of the original R
-    package, up to a tolerance in relative error, on a dataset with more genes than
-    samples.
-    """
+    """Test that the outputs of the DESeq2 function match those of the original R package, up to a tolerance in relative error, on a dataset with more genes than samples."""
 
     test_path = str(Path(os.path.realpath(tests.__file__)).parent.resolve())
 
@@ -662,8 +630,7 @@ def test_wide_deseq(
 
 def test_contrast(counts_df, metadata):
     """
-    Check that the contrasts ['condition', 'B', 'A'] and ['condition', 'A', 'B'] give
-    coherent results (change of sign in LFCs and Wald stats, same (adjusted p-values).
+    Check that the contrasts ['condition', 'B', 'A'] and ['condition', 'A', 'B'] give coherent results (change of sign in LFCs and Wald stats, same (adjusted p-values).
     """
 
     dds = DeseqDataSet(counts=counts_df, metadata=metadata, design="~group + condition")
@@ -695,8 +662,7 @@ def test_contrast(counts_df, metadata):
 
 def test_anndata_init(counts_df, metadata, tol=0.02):
     """
-    Test initializing dds with an AnnData object that already has filled in fields,
-    including with the same names as those used by pydeseq2.
+    Test initializing dds with an AnnData object that already has filled in fields, including with the same names as those used by pydeseq2.
     """
     np.random.seed(42)
 
@@ -804,9 +770,7 @@ def test_mean_vst(counts_df, metadata, tol=0.02):
 
 
 def test_deseq2_norm(counts_df, metadata):
-    """Test that deseq2_norm() called on a pandas dataframe outputs the same results as
-    DeseqDataSet.fit_size_factors()
-    """
+    """Test that deseq2_norm() called on a pandas dataframe outputs the same results as DeseqDataSet.fit_size_factors()"""
     # Fit size factors from DeseqDataSet
     dds = DeseqDataSet(counts=counts_df, metadata=metadata)
     dds.fit_size_factors()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -39,8 +39,7 @@ def test_nb_nll_moments(mu, alpha):
 @mock.patch("pathlib.Path.is_dir")
 def test_rtd_example_data_loading(mocked_function, modality, mocked_dir_flag):
     """
-    Test that load_example_data still works when run from a place where the ``datasets``
-    directory is not accessible, as is when the documentation is built on readthedocs.
+    Test that load_example_data still works when run from a place where the ``datasets`` directory is not accessible, as is when the documentation is built on readthedocs.
     """
 
     # Mock the output of is_dir() as False to emulate not having access to the


### PR DESCRIPTION
Drops the types from the Parameters, Attributes and Returns blocks of every docstring, since they are already declared in the signatures and rendered by sphinx-autodoc-typehints.
Docstring prose is reflowed one sentence per line, which makes E501 unenforceable on docstrings, so the rule is dropped from the ruff config.