### PR TITLE
Fix load_example_data for non-editable installs by bundling datasets/ into the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ typecheck = [
 [tool.hatch]
 version.source = "vcs"
 build.targets.wheel.packages = [ "src/pydeseq2" ]
+build.targets.wheel.force-include.datasets = "pydeseq2/datasets"
 envs.default.installer = "uv"
 envs.default.dependency-groups = [ "dev" ]
 envs.docs.scripts.build = "sphinx-build -M html docs docs/_build -W {args}"

--- a/src/pydeseq2/datasets.py
+++ b/src/pydeseq2/datasets.py
@@ -46,7 +46,9 @@ def load_example_data(
     )
 
     # Load data
-    datasets_path = Path(pydeseq2.__file__).parents[2] / "datasets"
+    datasets_path = Path(pydeseq2.__file__).parent / "datasets"
+    if not datasets_path.exists():
+        datasets_path = Path(pydeseq2.__file__).parents[2] / "datasets"
 
     if dataset == "synthetic":
         path_to_data = datasets_path / "synthetic"


### PR DESCRIPTION
Closes #464, closes #465, closes #466. `load_example_data()` located the bundled example data via `Path(pydeseq2.__file__).parents[2]`, which only resolves to the repo root for an editable, src-layout checkout — a normally installed (non-editable) wheel has no such parent, which is why the scverse integration-testing CI hit `FileNotFoundError`. Now `datasets/` is force-included into the wheel next to the package, and `load_example_data()` prefers that package-adjacent copy, falling back to the repo-root-relative path for editable checkouts.