### PR TITLE
Fix Wald thresholds for multi-coefficient and reversed contrasts

### DIFF
--- a/src/pydeseq2/glm.py
+++ b/src/pydeseq2/glm.py
@@ -261,7 +261,9 @@ def wald_test(
         return stat, pval
 
     def greater_abs(lfc_null):
-        stat = np.sign(contrast_lfc) * np.fmax((np.abs(contrast_lfc) - lfc_null) / wald_se, 0)
+        stat = np.sign(contrast_lfc) * np.fmax(
+            (np.abs(contrast_lfc) - lfc_null) / wald_se, 0
+        )
         pval = 2 * norm.sf(np.abs(stat))  # Only case where the test is two-tailed
         return stat, pval
 

--- a/src/pydeseq2/glm.py
+++ b/src/pydeseq2/glm.py
@@ -246,18 +246,22 @@ def wald_test(
     # Evaluate standard error and Wald statistic
     wald_se: float = np.sqrt(Hc.T @ M @ Hc)
 
+    # Apply the null and directional truncation to the tested scalar effect.
+    # Applying them coefficient-wise depends on the design parameterization.
+    contrast_lfc = contrast @ lfc
+
     def greater(lfc_null):
-        stat = contrast @ np.fmax((lfc - lfc_null) / wald_se, 0)
+        stat = np.fmax((contrast_lfc - lfc_null) / wald_se, 0)
         pval = norm.sf(stat)
         return stat, pval
 
     def less(lfc_null):
-        stat = contrast @ np.fmin((lfc - lfc_null) / wald_se, 0)
+        stat = np.fmin((contrast_lfc - lfc_null) / wald_se, 0)
         pval = norm.sf(np.abs(stat))
         return stat, pval
 
     def greater_abs(lfc_null):
-        stat = contrast @ (np.sign(lfc) * np.fmax((np.abs(lfc) - lfc_null) / wald_se, 0))
+        stat = np.sign(contrast_lfc) * np.fmax((np.abs(contrast_lfc) - lfc_null) / wald_se, 0)
         pval = 2 * norm.sf(np.abs(stat))  # Only case where the test is two-tailed
         return stat, pval
 
@@ -276,7 +280,7 @@ def wald_test(
             "less": less(lfc_null),
         }[alt_hypothesis]
     else:
-        wald_statistic = float(contrast @ (lfc - lfc_null) / wald_se)
+        wald_statistic = float((contrast_lfc - lfc_null) / wald_se)
         wald_p_value = 2 * norm.sf(np.abs(wald_statistic))
 
     return wald_p_value, wald_statistic, wald_se

--- a/tests/test_wald_contrasts.py
+++ b/tests/test_wald_contrasts.py
@@ -1,0 +1,53 @@
+import numpy as np
+import pytest
+from scipy.stats import norm
+
+from pydeseq2.glm import wald_test
+
+
+@pytest.mark.parametrize(
+    "alternative", [None, "greater", "less", "greaterAbs", "lessAbs"]
+)
+@pytest.mark.parametrize("null", [0.0, 1.5])
+@pytest.mark.parametrize(
+    "contrast",
+    [[0.0, -1.0, 1.0], [0.0, 1.0, -1.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0]],
+)
+def test_wald_tests_the_scalar_contrast(alternative, null, contrast):
+    # All tests concern the scalar effect c @ beta, including multi-coefficient
+    # and reversed contrasts. Thresholding individual coefficients is not invariant
+    # to the chosen model parameterization.
+    design = np.column_stack([np.ones(12), np.tile([0, 1, 0], 4), np.tile([0, 0, 1], 4)])
+    beta = np.array([4.0, 2.0, 3.0])
+    contrast = np.asarray(contrast)
+    mu = np.exp(design @ beta)
+    dispersion = 0.1
+    ridge = np.eye(3) * 1e-6
+    pvalue, statistic, se = wald_test(
+        design, dispersion, beta, mu, ridge, contrast, null, alternative
+    )
+    weight = mu / (1 + mu * dispersion)
+    information = design.T @ (weight[:, None] * design)
+    inverse = np.linalg.inv(information + ridge)
+    expected_se = np.sqrt(contrast @ inverse @ information @ inverse @ contrast)
+    effect = contrast @ beta
+    if alternative is None:
+        expected_stat = (effect - null) / expected_se
+        expected_p = 2 * norm.sf(abs(expected_stat))
+    elif alternative == "greater":
+        expected_stat = max((effect - null) / expected_se, 0)
+        expected_p = norm.sf(expected_stat)
+    elif alternative == "less":
+        expected_stat = min((effect - null) / expected_se, 0)
+        expected_p = norm.sf(abs(expected_stat))
+    elif alternative == "greaterAbs":
+        expected_stat = np.sign(effect) * max((abs(effect) - null) / expected_se, 0)
+        expected_p = 2 * norm.sf(abs(expected_stat))
+    else:
+        above = max((effect + abs(null)) / expected_se, 0)
+        below = min((effect - abs(null)) / expected_se, 0)
+        expected_stat = min(above, below, key=abs)
+        expected_p = max(norm.sf(abs(above)), norm.sf(abs(below)))
+    np.testing.assert_allclose(se, expected_se)
+    np.testing.assert_allclose(statistic, expected_stat)
+    np.testing.assert_allclose(pvalue, expected_p, atol=0)


### PR DESCRIPTION
Wald thresholds and directional truncation currently operate on each fitted coefficient before applying the contrast. For a multi-coefficient or reversed contrast, this tests a different hypothesis from the scalar effect `contrast @ lfc` and can make significance depend on the model reference level.

Apply the null and all four alternative-hypothesis transformations to the scalar contrast effect, retaining the existing contrast standard error. The ordinary nonzero-null calculation is corrected in the same way.

A public-API reproduction with fixed synthetic negative-binomial counts (90 samples, three groups, 100 genes) compares C versus B with `lfc_null=1.5` and `alt_hypothesis="greaterAbs"`. The estimated log2 fold change is approximately 0.986 with SE 0.0366 in both encodings. Before this patch, reference A produces p=1.53e-159 while reference B produces p=1; after it, both produce p=1. This reproduces in released 0.5.4 and the affected logic is present at current base `95ace12cfa39b6d5982c1867d8127a6b5e9e5134`.

Validation: 40 added scalar-normal-reference cases cover all five test modes, zero/nonzero nulls, multi-coefficient contrasts, reversed contrasts and positive singleton controls. Before the patch, 20 fail and 20 pass; all 40 pass after. Full local suite: **105 passed** on Python 3.12. Ruff passes for the changed files. Existing R-derived reference fixtures pass; no live R/DESeq2 execution is claimed. This does not establish an effect on a published analysis.

Prepared with AI assistance. [Audit and downloadable reproduction inputs, patches and execution records](https://cheerfulduck.com/research/audits/pydeseq2-contrast-threshold).

The upstream pre-commit.ci formatting-only commit was pulled locally; all 40 focused checks pass on final head `68f16c538f4e93ce3f2880aa4e713a330496a898`. The full-suite result above is from authored commit `a779e7bee6dc6791c1ff9666e781e4ec83e03c62`.
